### PR TITLE
Fix checkout failure in docker-release workflow

### DIFF
--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -9,6 +9,7 @@ env:
   IMAGE: ghcr.io/${{ github.repository }}
 
 permissions:
+  contents: read
   packages: write
 
 jobs:


### PR DESCRIPTION
## Summary

Add `contents: read` to the workflow permissions block. When only `packages: write` was set, all other permissions defaulted to `none`, causing `actions/checkout` to fail with "repository not found."

## What could break

Nothing — this only adds a read permission that was previously implicit before the explicit permissions block was added.

## How to test

Create a release and verify the docker-release workflow completes successfully.