### PR TITLE
Support OAuth refresh token auth for Anthropic

### DIFF
--- a/src/agent.ts
+++ b/src/agent.ts
@@ -17,7 +17,8 @@ const __dirname = dirname(fileURLToPath(import.meta.url));
 const projectDir = join(__dirname, "..");
 
 interface AgentConfig {
-  anthropicApiKey: string;
+  anthropicApiKey?: string;
+  anthropicOAuthRefreshToken?: string;
   githubToken?: string;
   model?: string;
 }
@@ -38,8 +39,19 @@ export function initAgent(config: AgentConfig): void {
     process.env.GITHUB_TOKEN = config.githubToken;
   }
 
-  authStorage = AuthStorage.inMemory();
-  authStorage.setRuntimeApiKey("anthropic", config.anthropicApiKey);
+  if (config.anthropicOAuthRefreshToken) {
+    authStorage = AuthStorage.inMemory({
+      anthropic: {
+        type: "oauth",
+        refresh: config.anthropicOAuthRefreshToken,
+        access: "",
+        expires: 0,
+      },
+    });
+  } else if (config.anthropicApiKey) {
+    authStorage = AuthStorage.inMemory();
+    authStorage.setRuntimeApiKey("anthropic", config.anthropicApiKey);
+  }
   modelId = config.model || "claude-sonnet-4-5";
 }
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -5,6 +5,7 @@ export interface Config {
   slackAppToken: string;
   githubToken: string;
   anthropicApiKey?: string;
+  anthropicOAuthRefreshToken?: string;
   model?: string;
   defaultRepos: string[];
   repoAliases: Record<string, string>;
@@ -17,6 +18,7 @@ export function loadConfig(): Config {
   const slackAppToken = requireEnv("SLACK_APP_TOKEN");
   const githubToken = requireEnv("GITHUB_TOKEN");
   const anthropicApiKey = process.env.ANTHROPIC_API_KEY;
+  const anthropicOAuthRefreshToken = process.env.ANTHROPIC_OAUTH_REFRESH_TOKEN;
   const model = process.env.MODEL;
   const defaultRepos = parseCommaSeparated(process.env.DEFAULT_REPOS);
   const repoAliases = parseAliases(process.env.REPO_ALIASES);
@@ -28,6 +30,7 @@ export function loadConfig(): Config {
     slackAppToken,
     githubToken,
     anthropicApiKey,
+    anthropicOAuthRefreshToken,
     model,
     defaultRepos,
     repoAliases,

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,13 +7,14 @@ const config = loadConfig();
 
 startHealthServer();
 
-if (!config.anthropicApiKey) {
-  console.error("ANTHROPIC_API_KEY is required");
+if (!config.anthropicApiKey && !config.anthropicOAuthRefreshToken) {
+  console.error("ANTHROPIC_API_KEY or ANTHROPIC_OAUTH_REFRESH_TOKEN is required");
   process.exit(1);
 }
 
 initAgent({
   anthropicApiKey: config.anthropicApiKey,
+  anthropicOAuthRefreshToken: config.anthropicOAuthRefreshToken,
   githubToken: config.githubToken,
   model: config.model,
 });


### PR DESCRIPTION
## Summary

- Add `ANTHROPIC_OAUTH_REFRESH_TOKEN` as an alternative to `ANTHROPIC_API_KEY` for authenticating with the Anthropic API
- When the OAuth refresh token is provided, seeds `AuthStorage` with an expired credential so the pi-agent library auto-refreshes on first use
- Fixes 401 errors caused by expired OAuth tokens when using `setRuntimeApiKey()`

## What could break

- If the refresh token itself is invalid or revoked, the bot will fail on the first prompt with an auth error (no graceful fallback)
- If both `ANTHROPIC_API_KEY` and `ANTHROPIC_OAUTH_REFRESH_TOKEN` are set, the OAuth path takes precedence

## How to test

1. Set `ANTHROPIC_OAUTH_REFRESH_TOKEN` in the App Platform env (value from `~/.pi/agent/auth.json`, the `anthropic.refresh` field)
2. Remove `ANTHROPIC_API_KEY` if set
3. Deploy and send a message to the bot in Slack
4. Verify logs show non-zero token usage and a successful response