### PR TITLE
Install gh CLI in Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM node:20-alpine
 
-RUN apk add --no-cache tini
+RUN apk add --no-cache tini github-cli
 
 WORKDIR /app
 


### PR DESCRIPTION
## Summary

- Add `github-cli` to the Alpine `apk install` in the Dockerfile
- The agent needs `gh` for all GitHub operations but it was missing from the image

## What could break

- Slightly larger Docker image due to the `github-cli` package

## How to test

1. Build the image and verify `gh --version` runs inside the container
2. Deploy and confirm the bot can search/read GitHub issues