### PR TITLE
Fix OAuth refresh token seed format

### DIFF
--- a/src/agent.ts
+++ b/src/agent.ts
@@ -83,7 +83,7 @@ async function initOAuthAgent(config: AgentConfig): Promise<void> {
   if (!seeded) {
     console.log("[agent] Seeding auth from ANTHROPIC_OAUTH_REFRESH_TOKEN env var");
     const seed = JSON.stringify({
-      anthropic: { refreshToken: config.anthropicOAuthRefreshToken },
+      anthropic: { type: "oauth", refresh: config.anthropicOAuthRefreshToken, access: "", expires: 0 },
     });
     writeFileSync(authPath, seed, "utf-8");
   }


### PR DESCRIPTION
## Summary

The OAuth refresh token seed written to `.auth.json` used `{ refreshToken: ... }` but `AuthStorage.getApiKey()` expects the `OAuthCredentials` shape `{ type: "oauth", refresh, access, expires }`. This caused "No API key found for anthropic" on cold start when using `ANTHROPIC_OAUTH_REFRESH_TOKEN` with no existing Redis state.

Setting `expires: 0` forces an immediate token refresh on first use.

## What could break

None — this only affects the cold-start seed path. Existing `.auth.json` files with real tokens are unaffected.

## How to test

1. Remove `.auth.json` and any Redis state
2. Set `ANTHROPIC_OAUTH_REFRESH_TOKEN` in env
3. Run `npm start` and trigger the bot via Slack mention
4. Confirm the bot responds successfully (no "No API key found" error)
5. Confirm `.auth.json` gets updated with a real access token after the first prompt