### PR TITLE
Log bot requests to audit channel

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -17,3 +17,6 @@ REPO_ALIASES=bevy:decentraland/bevy-explorer,mobile:decentraland/godot-explorer,
 # Optional: concurrency control for agent runs
 MAX_CONCURRENT_AGENTS=3
 MAX_QUEUE_SIZE=10
+
+# Optional: Slack channel ID for audit logging bot requests
+# LOG_CHANNEL_ID=C0123456789

--- a/src/config.ts
+++ b/src/config.ts
@@ -13,6 +13,7 @@ export interface Config {
   maxQueueSize: number;
   upstashRedisUrl?: string;
   upstashRedisToken?: string;
+  logChannelId?: string;
 }
 
 export function loadConfig(): Config {
@@ -29,6 +30,7 @@ export function loadConfig(): Config {
     maxQueueSize: parseInt(process.env.MAX_QUEUE_SIZE || "10", 10),
     upstashRedisUrl: process.env.UPSTASH_REDIS_REST_URL,
     upstashRedisToken: process.env.UPSTASH_REDIS_REST_TOKEN,
+    logChannelId: process.env.LOG_CHANNEL_ID,
   };
 }
 


### PR DESCRIPTION
## Summary

- Post a fire-and-forget log message to a dedicated Slack channel on every `app_mention`, including who triggered it, the channel, request text, and a permalink to the original message
- Gated behind the optional `LOG_CHANNEL_ID` env var — no-op when unset

## What could break

- If the bot lacks permission to post in the log channel, errors are caught and logged to stdout (no impact on the main flow)
- The `chat.getPermalink` call requires the bot to be in the channel where the mention happened (already the case for `app_mention` events)

## How to test

1. Create a Slack channel (e.g. `#bot-audit-log`) and note its channel ID
2. Set `LOG_CHANNEL_ID` to that ID
3. Mention the bot in another channel
4. Confirm a log message appears in `#bot-audit-log` with user, channel, text, and permalink
5. Confirm the bot still responds normally
6. Unset `LOG_CHANNEL_ID` and confirm no errors occur