### PR TITLE
Fix CLI OAuth auth failure on repeated runs

### DIFF
--- a/src/agent.ts
+++ b/src/agent.ts
@@ -61,14 +61,14 @@ export async function initAgent(config: AgentConfig): Promise<void> {
     console.log("[agent] Loaded auth state from Redis");
     writeFileSync(authPath, stored, "utf-8");
     lastAuthSnapshot = stored;
+  } else if (existsSync(authPath)) {
+    console.log("[agent] Using existing .auth.json");
   } else if (config.anthropicOAuthRefreshToken) {
     console.log("[agent] Seeding auth from ANTHROPIC_OAUTH_REFRESH_TOKEN env var");
     const seed = JSON.stringify({
       anthropic: { type: "oauth", refresh: config.anthropicOAuthRefreshToken, access: "", expires: 0 },
     });
     writeFileSync(authPath, seed, "utf-8");
-  } else if (existsSync(authPath)) {
-    console.log("[agent] Using existing .auth.json");
   } else {
     throw new Error(
       "No auth available. Set ANTHROPIC_OAUTH_REFRESH_TOKEN or place a valid .auth.json in the project root."


### PR DESCRIPTION
## Summary

- Swap priority of `.auth.json` check vs env var in `initAgent()` so existing rotated tokens on disk are preserved instead of being overwritten by the stale env var on every CLI run

## What could break

- If `.auth.json` exists but contains a revoked/corrupted token, the env var can no longer auto-fix it — the user must delete the file manually so the env var can re-seed

## How to test

1. Delete `.auth.json` so the env var seeds a fresh token
2. `npm run cli -- "hello"` — should authenticate and respond
3. `npm run cli -- "hello"` again — should still work (reuses the rotated token from `.auth.json`)