### PR TITLE
Post agent cost and token usage to audit channel

### DIFF
--- a/src/agent.ts
+++ b/src/agent.ts
@@ -36,6 +36,12 @@ export interface RunOptions {
   sessionId?: string;
 }
 
+export interface RunResult {
+  text: string;
+  cost: number;
+  tokens: number;
+}
+
 let authStorage: AuthStorage | null = null;
 let modelId: string;
 
@@ -113,7 +119,7 @@ async function redisSet(cfg: RedisConfig, value: string): Promise<void> {
   }
 }
 
-export async function runAgent(options: RunOptions): Promise<string> {
+export async function runAgent(options: RunOptions): Promise<RunResult> {
   if (!authStorage) {
     throw new Error("Agent not initialized — call initAgent() first");
   }
@@ -176,11 +182,12 @@ export async function runAgent(options: RunOptions): Promise<string> {
       console.log(`[agent]   role=${msg.role}${extra} content=${content}`);
     }
 
-    logUsage(session.messages);
+    const { cost, tokens } = computeUsage(session.messages);
+    console.log(`[agent] done — ${tokens} tokens, $${cost.toFixed(4)}`);
 
-    const result = session.getLastAssistantText() || "";
-    console.log("[agent] result length:", result.length);
-    return result;
+    const text = session.getLastAssistantText() || "";
+    console.log("[agent] result length:", text.length);
+    return { text, cost, tokens };
   } finally {
     session.dispose();
   }
@@ -205,16 +212,16 @@ function subscribeToTextDeltas(session: any, events: EventEmitter): void {
   });
 }
 
-function logUsage(messages: any[]): void {
-  let totalCost = 0;
-  let totalTokens = 0;
+function computeUsage(messages: any[]): { cost: number; tokens: number } {
+  let cost = 0;
+  let tokens = 0;
 
   for (const msg of messages) {
     if (msg.role === "assistant" && msg.usage) {
-      totalCost += msg.usage.cost?.total ?? 0;
-      totalTokens += msg.usage.totalTokens ?? 0;
+      cost += msg.usage.cost?.total ?? 0;
+      tokens += msg.usage.totalTokens ?? 0;
     }
   }
 
-  console.log(`[agent] done — ${totalTokens} tokens, $${totalCost.toFixed(4)}`);
+  return { cost, tokens };
 }

--- a/src/slack.ts
+++ b/src/slack.ts
@@ -41,7 +41,7 @@ export async function startSlackBot(config: Config): Promise<void> {
       await react("rl-bonk-doge");
 
       const threadContent = await fetchThread(client, event.channel, threadTs);
-      const response = await runAgent({ threadContent, sessionId: threadTs });
+      const { text: response, cost, tokens } = await runAgent({ threadContent, sessionId: threadTs });
       await syncAuth();
 
       await unreact("rl-bonk-doge");
@@ -51,6 +51,11 @@ export async function startSlackBot(config: Config): Promise<void> {
       } else {
         await react("warning");
         await say({ text: "I wasn't able to produce a response.", thread_ts: threadTs });
+      }
+
+      if (config.logChannelId) {
+        postCompletionAuditLog(client, config.logChannelId, event, cost, tokens)
+          .catch((err) => console.error("[slack] Failed to post completion log:", err));
       }
     });
 
@@ -120,6 +125,19 @@ async function postAuditLog(
   await client.chat.postMessage({
     channel: logChannelId,
     text: `*<@${event.user}>* in <#${event.channel}>: ${text}\n<${permalink}|View message>`,
+  });
+}
+
+async function postCompletionAuditLog(
+  client: WebClient,
+  logChannelId: string,
+  event: { channel: string; user?: string },
+  cost: number,
+  tokens: number,
+): Promise<void> {
+  await client.chat.postMessage({
+    channel: logChannelId,
+    text: `✅ <@${event.user}> in <#${event.channel}> — $${cost.toFixed(4)} (${tokens} tokens)`,
   });
 }
 


### PR DESCRIPTION
## Summary
- Return cost/token data from `runAgent()` via a new `RunResult` interface instead of only logging it
- Post a completion audit message to the log channel after each agent run
- Refactor `logUsage()` into `computeUsage()` to separate computation from side effects

## What could break
- Callers of `runAgent()` now receive `RunResult` instead of `string` — the CLI discards the return value so it's unaffected, but any future callers need `.text` for the response

## How to test
- `npm test` — all 19 tests pass
- `npm run cli` — run a query, confirm console still logs cost
- Deploy and trigger a mention in Slack — verify the audit channel receives a completion message with cost and token count