### PR TITLE
Queue requests instead of dropping them

### DIFF
--- a/src/concurrency.ts
+++ b/src/concurrency.ts
@@ -1,18 +1,15 @@
 export type SubmitResult =
   | "thread-busy"
-  | "queue-full"
-  | { status: "accepted"; done: Promise<void> };
+  | { status: "accepted"; done: Promise<void>; queued: boolean };
 
 export class AgentScheduler {
   private activeThreads = new Set<string>();
   private running = 0;
   private waitQueue: Array<() => void> = [];
   private maxConcurrent: number;
-  private maxQueue: number;
 
-  constructor(maxConcurrent = 3, maxQueue = 10) {
+  constructor(maxConcurrent = 3) {
     this.maxConcurrent = maxConcurrent;
-    this.maxQueue = maxQueue;
   }
 
   submit(threadId: string, work: () => Promise<void>): SubmitResult {
@@ -20,14 +17,11 @@ export class AgentScheduler {
       return "thread-busy";
     }
 
-    if (this.running >= this.maxConcurrent && this.waitQueue.length >= this.maxQueue) {
-      return "queue-full";
-    }
-
+    const queued = this.running >= this.maxConcurrent;
     this.activeThreads.add(threadId);
     const done = this.execute(threadId, work);
 
-    return { status: "accepted", done };
+    return { status: "accepted", done, queued };
   }
 
   private async execute(threadId: string, work: () => Promise<void>): Promise<void> {

--- a/src/config.ts
+++ b/src/config.ts
@@ -7,7 +7,6 @@ export interface Config {
   anthropicOAuthRefreshToken?: string;
   model?: string;
   maxConcurrentAgents: number;
-  maxQueueSize: number;
   upstashRedisUrl?: string;
   upstashRedisToken?: string;
   logChannelId?: string;
@@ -22,7 +21,6 @@ export function loadConfig(): Config {
     anthropicOAuthRefreshToken: process.env.ANTHROPIC_OAUTH_REFRESH_TOKEN,
     model: process.env.MODEL,
     maxConcurrentAgents: parseInt(process.env.MAX_CONCURRENT_AGENTS || "3", 10),
-    maxQueueSize: parseInt(process.env.MAX_QUEUE_SIZE || "10", 10),
     upstashRedisUrl: process.env.UPSTASH_REDIS_REST_URL,
     upstashRedisToken: process.env.UPSTASH_REDIS_REST_TOKEN,
     logChannelId: process.env.LOG_CHANNEL_ID,

--- a/src/slack.ts
+++ b/src/slack.ts
@@ -13,7 +13,7 @@ export async function startSlackBot(config: Config): Promise<void> {
     socketMode: true,
   });
 
-  const scheduler = new AgentScheduler(config.maxConcurrentAgents, config.maxQueueSize);
+  const scheduler = new AgentScheduler(config.maxConcurrentAgents);
 
   app.event("app_mention", async ({ event, client, say }) => {
     const threadTs = event.thread_ts || event.ts;
@@ -59,9 +59,8 @@ export async function startSlackBot(config: Config): Promise<void> {
       return;
     }
 
-    if (submission === "queue-full") {
-      await say({ text: "I'm handling too many requests right now. Please try again in a moment.", thread_ts: threadTs });
-      return;
+    if (submission.queued) {
+      await say({ text: "I'm busy right now but your request is queued — I'll get to it shortly.", thread_ts: threadTs });
     }
 
     submission.done.catch(async (err) => {

--- a/test/concurrency.test.ts
+++ b/test/concurrency.test.ts
@@ -2,7 +2,7 @@ import { describe, it } from "node:test";
 import assert from "node:assert/strict";
 import { AgentScheduler, type SubmitResult } from "../src/concurrency.js";
 
-function accepted(result: SubmitResult): asserts result is { status: "accepted"; done: Promise<void> } {
+function accepted(result: SubmitResult): asserts result is { status: "accepted"; done: Promise<void>; queued: boolean } {
   assert.ok(typeof result === "object" && result.status === "accepted");
 }
 
@@ -51,11 +51,29 @@ describe("AgentScheduler", () => {
     assert.deepEqual(order, [1, 2]);
   });
 
-  it("returns queue-full when saturated", () => {
-    const scheduler = new AgentScheduler(1, 1);
-    scheduler.submit("t1", () => new Promise(() => {})); // fills the running slot
-    scheduler.submit("t2", () => new Promise(() => {})); // fills the queue
-    assert.equal(scheduler.submit("t3", async () => {}), "queue-full");
+  it("queues excess work instead of rejecting", async () => {
+    const scheduler = new AgentScheduler(1);
+    const order: number[] = [];
+    let resolve1!: () => void;
+    const blocker = new Promise<void>((r) => { resolve1 = r; });
+
+    const r1 = scheduler.submit("t1", async () => { await blocker; order.push(1); });
+    accepted(r1);
+    assert.equal(r1.queued, false);
+
+    const r2 = scheduler.submit("t2", async () => { order.push(2); });
+    accepted(r2);
+    assert.equal(r2.queued, true);
+
+    const r3 = scheduler.submit("t3", async () => { order.push(3); });
+    accepted(r3);
+    assert.equal(r3.queued, true);
+
+    resolve1();
+    await r1.done;
+    await r2.done;
+    await r3.done;
+    assert.deepEqual(order, [1, 2, 3]);
   });
 
   it("propagates errors from work", async () => {
@@ -73,25 +91,5 @@ describe("AgentScheduler", () => {
     const r2 = scheduler.submit("t1", async () => {});
     accepted(r2);
     await r2.done;
-  });
-
-  it("drains queue in FIFO order", async () => {
-    const scheduler = new AgentScheduler(1);
-    const order: string[] = [];
-    let resolve1!: () => void;
-    const blocker = new Promise<void>((r) => { resolve1 = r; });
-
-    const r1 = scheduler.submit("t1", async () => { await blocker; order.push("a"); });
-    accepted(r1);
-    const r2 = scheduler.submit("t2", async () => { order.push("b"); });
-    accepted(r2);
-    const r3 = scheduler.submit("t3", async () => { order.push("c"); });
-    accepted(r3);
-
-    resolve1();
-    await r1.done;
-    await r2.done;
-    await r3.done;
-    assert.deepEqual(order, ["a", "b", "c"]);
   });
 });


### PR DESCRIPTION
## Summary
- Remove the queue size cap so every request is accepted and processed in FIFO order instead of being rejected with "queue-full"
- Notify users when their request is queued ("I'm busy right now but your request is queued — I'll get to it shortly")
- Remove `maxQueueSize` from config since the queue is now unbounded

## What could break
- Under extreme load the queue can grow without bound, increasing memory usage. In practice the bot's throughput is limited by Slack rate limits and agent runtimes so this is unlikely to be an issue.

## How to test
- Start with `MAX_CONCURRENT_AGENTS=1`
- Send two mentions in quick succession from different threads
- First should run immediately, second should get the "queued" message and run after the first finishes
- `npm test` passes (18 tests)