### PR TITLE
Fix thread token consumption growing with each message

### DIFF
--- a/src/agent.ts
+++ b/src/agent.ts
@@ -1,4 +1,4 @@
-import { readFileSync, writeFileSync, existsSync, mkdirSync } from "node:fs";
+import { readFileSync, writeFileSync, existsSync } from "node:fs";
 import { join, dirname } from "node:path";
 import { fileURLToPath } from "node:url";
 import { EventEmitter } from "node:events";
@@ -33,7 +33,6 @@ export interface RunOptions {
   threadContent: string;
   dryRun?: boolean;
   events?: EventEmitter;
-  sessionId?: string;
 }
 
 export interface RunResult {
@@ -124,8 +123,8 @@ export async function runAgent(options: RunOptions): Promise<RunResult> {
     throw new Error("Agent not initialized — call initAgent() first");
   }
 
-  const { threadContent, dryRun, events, sessionId } = options;
-  const sessionManager = createSessionManager(sessionId);
+  const { threadContent, dryRun, events } = options;
+  const sessionManager = SessionManager.inMemory();
 
   const systemPrompt = readFileSync(
     join(projectDir, "prompts/system.md"),
@@ -191,14 +190,6 @@ export async function runAgent(options: RunOptions): Promise<RunResult> {
   } finally {
     session.dispose();
   }
-}
-
-function createSessionManager(sessionId?: string): SessionManager {
-  if (!sessionId) return SessionManager.inMemory();
-
-  const sessionsDir = join(projectDir, "sessions");
-  mkdirSync(sessionsDir, { recursive: true });
-  return SessionManager.open(join(sessionsDir, `${sessionId}.jsonl`));
 }
 
 function subscribeToTextDeltas(session: any, events: EventEmitter): void {

--- a/src/slack.ts
+++ b/src/slack.ts
@@ -36,7 +36,7 @@ export async function startSlackBot(config: Config): Promise<void> {
       await react("rl-bonk-doge");
 
       const threadContent = await fetchThread(client, event.channel, threadTs);
-      const { text: response, cost, tokens } = await runAgent({ threadContent, sessionId: threadTs });
+      const { text: response, cost, tokens } = await runAgent({ threadContent });
       await syncAuth();
 
       await unreact("rl-bonk-doge");


### PR DESCRIPTION
## Summary

- Switch from persistent JSONL sessions to in-memory sessions to eliminate near-quadratic token growth in Slack threads
- Each invocation was loading all prior conversation turns (which already contained the full thread) on top of re-fetching the thread via `fetchThread()`, causing ~30-50K token growth per message
- Token usage per message should now stay flat (~250K baseline) instead of climbing to 500K+ over a 7-message thread

## What could break

- Claude loses tool call history between invocations (e.g. which bash commands it ran). The thread already contains bot replies with results, so context is preserved through the conversation itself.

## How to test

1. `npm test` — all 18 tests pass
2. Send several messages in a Slack thread and observe token counts in the audit channel — should stay roughly constant instead of growing linearly