### PR TITLE
Remove stale config and update skills lists

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -13,7 +13,6 @@ GITHUB_TOKEN=ghp_...
 
 # Optional: concurrency control for agent runs
 MAX_CONCURRENT_AGENTS=3
-MAX_QUEUE_SIZE=10
 
 # Optional: Slack channel ID for audit logging bot requests
 # LOG_CHANNEL_ID=C0123456789

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -29,7 +29,7 @@ src/
 - **Agent SDK**: uses `@mariozechner/pi-coding-agent` (pi-agent) to run Claude with tool use
   - Agent tools: `createCodingTools(cwd)` provides bash, read, edit, and write tools
 - **Concurrency**: bounded agent pool (`MAX_CONCURRENT_AGENTS`) with a queue (`MAX_QUEUE_SIZE`)
-- **Skills**: prompt-based tool definitions in `skills/` (create-issue, create-pr, github, mobile-project, pr-review, repos, triage)
+- **Skills**: prompt-based tool definitions in `skills/` (create-issue, github, mobile-project, pr-review, repos, triage)
 - **System prompt**: `prompts/system.md`
 
 ## Auth — OAuth only, never API keys

--- a/README.md
+++ b/README.md
@@ -52,7 +52,6 @@ See [`.env.example`](.env.example) for all available options. Key variables:
 | `ANTHROPIC_OAUTH_REFRESH_TOKEN` | No* | Anthropic OAuth refresh token (see Auth section) |
 | `MODEL` | No | Model override (default: `claude-sonnet-4-5`) |
 | `MAX_CONCURRENT_AGENTS` | No | Max parallel agent runs (default: 3) |
-| `MAX_QUEUE_SIZE` | No | Max queued requests (default: 10) |
 | `UPSTASH_REDIS_REST_URL` | No | Upstash Redis URL for OAuth token persistence |
 | `UPSTASH_REDIS_REST_TOKEN` | No | Upstash Redis token |
 | `LOG_CHANNEL_ID` | No | Slack channel ID for audit logging |
@@ -107,5 +106,5 @@ src/
 test/               Unit tests (node:test)
 prompts/
   system.md         System prompt for the Claude agent
-skills/             Agent skill definitions (create-issue, github, repos, triage)
+skills/             Agent skill definitions (create-issue, github, mobile-project, pr-review, repos, triage)
 ```


### PR DESCRIPTION
## Summary
- Remove `MAX_QUEUE_SIZE` from `.env.example` and README config table (queue is now managed internally after #19)
- Remove stale `create-pr` skill from CLAUDE.md skills list (disabled in #16)
- Add missing `mobile-project` and `pr-review` to README skills list

## What could break
Nothing — documentation-only changes.

## How to test
- Verify `ls skills/` matches the lists in both CLAUDE.md and README.md
- Confirm `MAX_QUEUE_SIZE` is not referenced in `config.ts` or `.env.example`