### PR TITLE
Add triggered-by attribution to bot-created artifacts

### DIFF
--- a/prompts/system.md
+++ b/prompts/system.md
@@ -26,6 +26,11 @@ You read Slack thread conversations and respond to whatever is being asked. You 
 
 Your response will be posted back to the Slack thread — keep it concise and well-formatted for Slack.
 
+## Attribution
+
+When the prompt includes a "Triggered by" line, include attribution in any GitHub artifact you create
+(issues, comments, etc.). Add "Requested by {name} via Slack" at the bottom of the body.
+
 ## Slack formatting (mrkdwn)
 
 Slack does NOT use standard Markdown. Use Slack's mrkdwn syntax:

--- a/skills/create-issue/SKILL.md
+++ b/skills/create-issue/SKILL.md
@@ -46,4 +46,5 @@ gh issue create --repo {repo} --title "..." --body "..." --label "bug,Android,cl
 - Don't include every message — synthesize the key points
 - Include relevant code snippets or error messages from the thread
 - If participants disagreed, note the different perspectives
+- Include "Requested by {name} via Slack" as the last line of the issue body, using the name from the "Triggered by" metadata. Omit if no "Triggered by" is present.
 - Always output the created issue URL as the last line, prefixed with `ISSUE_URL:`

--- a/src/agent.ts
+++ b/src/agent.ts
@@ -32,6 +32,7 @@ interface AgentConfig {
 export interface RunOptions {
   threadContent: string;
   dryRun?: boolean;
+  triggeredBy?: string;
   events?: EventEmitter;
 }
 
@@ -123,7 +124,7 @@ export async function runAgent(options: RunOptions): Promise<RunResult> {
     throw new Error("Agent not initialized — call initAgent() first");
   }
 
-  const { threadContent, dryRun, events } = options;
+  const { threadContent, dryRun, triggeredBy, events } = options;
   const sessionManager = SessionManager.inMemory();
 
   const systemPrompt = readFileSync(
@@ -160,7 +161,7 @@ export async function runAgent(options: RunOptions): Promise<RunResult> {
   });
 
   try {
-    const prompt = buildPrompt(threadContent, dryRun);
+    const prompt = buildPrompt(threadContent, dryRun, triggeredBy);
 
     if (events) {
       subscribeToTextDeltas(session, events);

--- a/src/prompt.ts
+++ b/src/prompt.ts
@@ -1,7 +1,11 @@
-export function buildPrompt(threadContent: string, dryRun?: boolean): string {
+export function buildPrompt(threadContent: string, dryRun?: boolean, triggeredBy?: string): string {
   const dryRunNotice = dryRun
     ? "IMPORTANT: Do not execute any commands. Just describe what you would do.\n\n"
     : "";
 
-  return `${dryRunNotice}## Slack Thread\n\n<slack-thread>\n${threadContent}\n</slack-thread>`;
+  const attribution = triggeredBy
+    ? `Triggered by: ${triggeredBy}\n\n`
+    : "";
+
+  return `${dryRunNotice}${attribution}## Slack Thread\n\n<slack-thread>\n${threadContent}\n</slack-thread>`;
 }

--- a/src/slack.ts
+++ b/src/slack.ts
@@ -36,7 +36,7 @@ export async function startSlackBot(config: Config): Promise<void> {
       await react("rl-bonk-doge");
 
       const threadContent = await fetchThread(client, event.channel, threadTs);
-      const { text: response, cost, tokens } = await runAgent({ threadContent });
+      const { text: response, cost, tokens } = await runAgent({ threadContent, triggeredBy: userName });
       await syncAuth();
 
       await unreact("rl-bonk-doge");

--- a/test/prompt.test.ts
+++ b/test/prompt.test.ts
@@ -28,4 +28,14 @@ describe("buildPrompt", () => {
     const result = buildPrompt(content);
     assert.ok(result.includes(content));
   });
+
+  it("includes triggeredBy when provided", () => {
+    const result = buildPrompt("hello", false, "Alice");
+    assert.ok(result.includes("Triggered by: Alice"));
+  });
+
+  it("omits triggeredBy when not provided", () => {
+    const result = buildPrompt("hello");
+    assert.ok(!result.includes("Triggered by:"));
+  });
 });


### PR DESCRIPTION
## Summary

- Threads the Slack user's name (`triggeredBy`) from `slack.ts` through `agent.ts` into `buildPrompt`, so the agent knows who requested the action
- Instructs the agent (via `system.md` and `create-issue/SKILL.md`) to include "Requested by {name} via Slack" at the bottom of any GitHub artifact it creates
- Attribution is omitted when `triggeredBy` is absent (e.g. CLI usage)

## What could break

- The attribution line is prompt-based, so the agent may occasionally omit or rephrase it. No code-level enforcement.
- No impact on existing behavior when `triggeredBy` is not provided.

## How to test

- `npm test` — all 20 tests pass (includes 2 new cases for `buildPrompt`)
- `npm run cli "Create an issue about a login bug in decentraland/godot-explorer"` — verify no crash and no attribution (since `triggeredBy` is absent)
- Deploy and trigger from Slack — verify the created issue body ends with "Requested by {name} via Slack"