### PR TITLE
Fix silent WebSocket disconnect

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,11 @@
+process.on("unhandledRejection", (err) => {
+  console.error("[process] Unhandled rejection:", err);
+});
+process.on("uncaughtException", (err) => {
+  console.error("[process] Uncaught exception:", err);
+  process.exit(1);
+});
+
 import { loadConfig } from "./config.js";
 import { initAgent } from "./agent.js";
 import { startSlackBot } from "./slack.js";

--- a/src/slack.ts
+++ b/src/slack.ts
@@ -1,4 +1,4 @@
-import { App } from "@slack/bolt";
+import { App, LogLevel } from "@slack/bolt";
 import type { WebClient } from "@slack/web-api";
 import type { Config } from "./config.js";
 import { runAgent, syncAuth } from "./agent.js";
@@ -11,6 +11,7 @@ export async function startSlackBot(config: Config): Promise<void> {
     token: config.slackBotToken,
     appToken: config.slackAppToken,
     socketMode: true,
+    logLevel: LogLevel.INFO,
   });
 
   const scheduler = new AgentScheduler(config.maxConcurrentAgents);
@@ -26,10 +27,12 @@ export async function startSlackBot(config: Config): Promise<void> {
     console.log(`[slack] Triggered by ${userName} in #${channelName}: ${text}`);
 
     function react(name: string): Promise<unknown> {
-      return client.reactions.add({ channel: event.channel, timestamp: event.ts, name });
+      return client.reactions.add({ channel: event.channel, timestamp: event.ts, name })
+        .catch((err) => { if (err.data?.error !== "already_reacted") throw err; });
     }
     function unreact(name: string): Promise<unknown> {
-      return client.reactions.remove({ channel: event.channel, timestamp: event.ts, name });
+      return client.reactions.remove({ channel: event.channel, timestamp: event.ts, name })
+        .catch((err) => { if (err.data?.error !== "no_reaction") throw err; });
     }
 
     const submission = scheduler.submit(threadTs, async () => {
@@ -75,6 +78,10 @@ export async function startSlackBot(config: Config): Promise<void> {
           .catch((e) => console.error("[slack] Failed to post audit log:", e));
       }
     });
+  });
+
+  app.error(async (error) => {
+    console.error("[slack] Bolt error:", error);
   });
 
   await app.start();


### PR DESCRIPTION
## Summary
- Add `process.on("unhandledRejection")` and `process.on("uncaughtException")` handlers in `index.ts` so the process never dies silently
- Enable `LogLevel.INFO` on the Bolt app to surface WebSocket lifecycle events (connect, reconnect, disconnect)
- Register `app.error()` handler to catch Bolt-internal errors
- Guard `react()`/`unreact()` calls against benign `already_reacted` / `no_reaction` Slack API errors that could surface as unhandled rejections

## What could break
- `LogLevel.INFO` will produce more stdout output — could be noisy in production logs
- `uncaughtException` handler calls `process.exit(1)`, which is intentional (crash loudly rather than run in a broken state)

## How to test
1. `npm run dev` — observe socket-mode lifecycle logs (connect, hello)
2. Mention the bot twice rapidly in the same thread — should not crash from `already_reacted`
3. Kill network briefly and verify reconnection is logged