### PR TITLE
Use Opus for PR review requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ See [`.env.example`](.env.example) for all available options. Key variables:
 | `SLACK_APP_TOKEN` | Yes | App-level token for Socket Mode (`xapp-...`) |
 | `GITHUB_TOKEN` | Yes | GitHub PAT for `gh` CLI |
 | `ANTHROPIC_OAUTH_REFRESH_TOKEN` | No* | Anthropic OAuth refresh token (see Auth section) |
-| `MODEL` | No | Model override (default: `claude-sonnet-4-5`) |
+| `MODEL` | No | Model override (default: `claude-sonnet-4-5`). PR reviews always use `claude-opus-4-6` regardless of this setting. |
 | `MAX_CONCURRENT_AGENTS` | No | Max parallel agent runs (default: 3) |
 | `UPSTASH_REDIS_REST_URL` | No | Upstash Redis URL for OAuth token persistence |
 | `UPSTASH_REDIS_REST_TOKEN` | No | Upstash Redis token |

--- a/src/agent.ts
+++ b/src/agent.ts
@@ -34,7 +34,12 @@ export interface RunOptions {
   dryRun?: boolean;
   triggeredBy?: string;
   events?: EventEmitter;
+  model?: string;
 }
+
+export const REVIEW_MODEL = "claude-opus-4-6";
+export const PR_URL_PATTERN = /github\.com\/[^/]+\/[^/]+\/pull\/\d+/;
+export const REVIEW_KEYWORD_PATTERN = /\breview\b/i;
 
 export interface RunResult {
   text: string;
@@ -125,6 +130,7 @@ export async function runAgent(options: RunOptions): Promise<RunResult> {
   }
 
   const { threadContent, dryRun, triggeredBy, events } = options;
+  const effectiveModelId = options.model || modelId;
   const sessionManager = SessionManager.inMemory();
 
   const systemPrompt = readFileSync(
@@ -133,9 +139,9 @@ export async function runAgent(options: RunOptions): Promise<RunResult> {
   ).trim();
 
   const modelRegistry = new ModelRegistry(authStorage);
-  const model = modelRegistry.find("anthropic", modelId);
+  const model = modelRegistry.find("anthropic", effectiveModelId);
   if (!model) {
-    throw new Error(`Model "anthropic/${modelId}" not found`);
+    throw new Error(`Model "anthropic/${effectiveModelId}" not found`);
   }
 
   const cwd = process.cwd();
@@ -169,7 +175,7 @@ export async function runAgent(options: RunOptions): Promise<RunResult> {
 
     console.log("[agent] running prompt...");
     console.log("[agent] prompt:", prompt.slice(0, 200));
-    console.log("[agent] model:", modelId);
+    console.log("[agent] model:", effectiveModelId);
     await session.prompt(prompt);
 
     const messageCount = session.messages.length;

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,7 +1,7 @@
 import "dotenv/config";
 import { EventEmitter } from "node:events";
 import { createInterface } from "node:readline";
-import { initAgent, runAgent } from "./agent.js";
+import { initAgent, runAgent, REVIEW_MODEL, PR_URL_PATTERN, REVIEW_KEYWORD_PATTERN } from "./agent.js";
 
 const dryRun = process.argv.includes("--dry-run");
 const positionalArgs = process.argv.slice(2).filter((a) => a !== "--dry-run");
@@ -18,13 +18,20 @@ function streamingEvents(): EventEmitter {
   return events;
 }
 
+function detectReviewModel(content: string): string | undefined {
+  const isReview =
+    PR_URL_PATTERN.test(content) ||
+    REVIEW_KEYWORD_PATTERN.test(content);
+  return isReview ? REVIEW_MODEL : undefined;
+}
+
 if (positionalArgs.length > 0) {
   // One-shot mode
   const threadContent = positionalArgs.join(" ");
   if (dryRun) console.log("Dry run enabled — agent will not execute commands");
 
   try {
-    await runAgent({ threadContent, dryRun, events: streamingEvents() });
+    await runAgent({ threadContent, dryRun, model: detectReviewModel(threadContent), events: streamingEvents() });
     console.log();
   } catch (err) {
     console.error("Error:", err instanceof Error ? err.message : err);
@@ -56,7 +63,7 @@ if (positionalArgs.length > 0) {
     console.log("\n--- Agent running ---\n");
 
     try {
-      await runAgent({ threadContent, dryRun, events: streamingEvents() });
+      await runAgent({ threadContent, dryRun, model: detectReviewModel(threadContent), events: streamingEvents() });
       console.log("\n\n--- Done ---\n");
     } catch (err) {
       console.error("Error:", err instanceof Error ? err.message : err);

--- a/src/slack.ts
+++ b/src/slack.ts
@@ -1,7 +1,7 @@
 import { App, LogLevel } from "@slack/bolt";
 import type { WebClient } from "@slack/web-api";
 import type { Config } from "./config.js";
-import { runAgent, syncAuth } from "./agent.js";
+import { runAgent, syncAuth, REVIEW_MODEL, PR_URL_PATTERN, REVIEW_KEYWORD_PATTERN } from "./agent.js";
 import { AgentScheduler } from "./concurrency.js";
 
 const nameCache = new Map<string, string>();
@@ -39,7 +39,15 @@ export async function startSlackBot(config: Config): Promise<void> {
       await react("rl-bonk-doge");
 
       const threadContent = await fetchThread(client, event.channel, threadTs);
-      const { text: response, cost, tokens } = await runAgent({ threadContent, triggeredBy: userName });
+      const isReview =
+        PR_URL_PATTERN.test(threadContent) ||
+        REVIEW_KEYWORD_PATTERN.test(text);
+      const model = isReview ? REVIEW_MODEL : undefined;
+      const { text: response, cost, tokens } = await runAgent({
+        threadContent,
+        triggeredBy: userName,
+        model,
+      });
       await syncAuth();
 
       await unreact("rl-bonk-doge");


### PR DESCRIPTION
## Summary

- Detect review requests by checking for GitHub PR URLs or the word "review" and route them to `claude-opus-4-6` for stronger reasoning
- All other requests continue using the default model (`claude-sonnet-4-5`)
- Detection patterns are exported as shared constants from `agent.ts` to avoid duplication

## What could break

- False positives: any message containing "review" (e.g., "review this issue") will use Opus — this is intentional since false positives just use a slightly better (more expensive) model
- If `claude-opus-4-6` is not available in the model registry, `runAgent()` will throw

## How to test

1. Mention the bot with a PR URL (e.g., "review https://github.com/org/repo/pull/123") — logs should show `model: claude-opus-4-6`
2. Mention the bot with a regular request (e.g., "create an issue for X") — logs should show `model: claude-sonnet-4-5`
3. Test via CLI: `npm run cli -- "review this PR https://github.com/org/repo/pull/1"`
4. `npm test` — all 20 tests pass