### PR TITLE
Use bug template for godot-explorer issues

### DIFF
--- a/skills/create-issue/SKILL.md
+++ b/skills/create-issue/SKILL.md
@@ -27,7 +27,7 @@ These are not mandatory — use your judgment based on the content:
 - **Context** — key decisions, details, or constraints from the conversation
 - **Related Issues** — links to related issues found in step 2
 
-For bugs, try to include the platform (Android, iOS, desktop, VR) and app version if mentioned in the thread, but don't enforce a strict template — just capture what's useful.
+For bugs in `decentraland/godot-explorer`, use the bug report template defined in the mobile-project skill instead of freeform sections.
 
 ## Labels and Assignees
 

--- a/skills/mobile-project/SKILL.md
+++ b/skills/mobile-project/SKILL.md
@@ -107,6 +107,41 @@ Cross-platform metaverse client combining Godot Engine 4.5.1 (custom fork) + Rus
 - Use `planning` or `need definition` when requirements are vague
 - Add `claw-created` to all issues created by this bot
 
+## Bug Report Template
+
+When creating bug issues in `decentraland/godot-explorer`, format the issue body using these headers to match the repo's bug report template. Always include the `bug` label.
+
+```markdown
+### Platform
+<!-- Android, iOS, Web Client -->
+
+### App Version
+<!-- e.g. 0.5.2, or "Not specified" -->
+
+### Device Information
+<!-- e.g. Samsung Galaxy S24, iPhone 15 Pro, or "Not specified" -->
+
+### Issue Description
+<!-- Clear summary of what's broken -->
+
+### Expected Behavior
+<!-- What should happen instead -->
+
+### Screenshots / Media
+<!-- Only include this section if media was shared in the thread -->
+
+### Steps to Reproduce
+<!-- Numbered steps to trigger the bug -->
+
+### Occurrence
+<!-- How often: 100%, ~75%, ~50%, <25% -->
+```
+
+- Extract all available information from the Slack thread
+- Use "Not specified" for required fields when information is missing
+- Omit the "Screenshots / Media" section entirely if no media was shared
+- Always include the `bug` label alongside other relevant labels
+
 ## Architecture
 
 ### Directory Structure


### PR DESCRIPTION
## Summary
- Add structured bug report template to mobile-project skill matching the repo's `bug_report.yml` (Platform, App Version, Device Info, Issue Description, Expected Behavior, Screenshots/Media, Steps to Reproduce, Occurrence)
- Update create-issue skill to reference the template instead of freeform bug guidance
- Bug issues in `decentraland/godot-explorer` will now always include the `bug` label

## What could break
- Existing bug creation flows will produce differently formatted issues (structured vs freeform)

## How to test
- Ask the bot to create a bug in `decentraland/godot-explorer` from a Slack thread
- Verify the issue body uses the template headers and includes the `bug` label

Closes #29