### PR TITLE
Restrict bot access to organization members

### DIFF
--- a/src/slack.ts
+++ b/src/slack.ts
@@ -20,6 +20,11 @@ export async function startSlackBot(config: Config): Promise<void> {
     const threadTs = event.thread_ts || event.ts;
     const text = event.text.replace(/<@[A-Z0-9]+>/g, "").trim();
 
+    if (event.user && await isExternalOrGuest(client, event.user)) {
+      console.warn(`[slack] Denied request from non-org user ${event.user}`);
+      return;
+    }
+
     const [userName, channelName] = await Promise.all([
       event.user ? resolveUserName(client, event.user) : Promise.resolve("unknown"),
       resolveChannelName(client, event.channel),
@@ -109,6 +114,35 @@ async function cachedLookup(
     return name;
   } catch {
     return key;
+  }
+}
+
+interface AuthEntry {
+  denied: boolean;
+  cachedAt: number;
+}
+
+const authCache = new Map<string, AuthEntry>();
+const AUTH_CACHE_TTL_MS = 60 * 60 * 1000; // 1 hour
+
+async function isExternalOrGuest(client: WebClient, userId: string): Promise<boolean> {
+  const cached = authCache.get(userId);
+  if (cached && Date.now() - cached.cachedAt <= AUTH_CACHE_TTL_MS) return cached.denied;
+
+  try {
+    const info = await client.users.info({ user: userId });
+    const user = info.user as any;
+    const denied = Boolean(user?.is_restricted || user?.is_ultra_restricted || user?.is_stranger);
+    authCache.set(userId, { denied, cachedAt: Date.now() });
+
+    // Cache the user name too, so resolveUserName won't re-fetch
+    const name = info.user?.real_name || info.user?.name;
+    if (name) nameCache.set(userId, name);
+
+    return denied;
+  } catch (err) {
+    console.error(`[slack] Failed to check user ${userId}, denying by default:`, err);
+    return true;
   }
 }
 


### PR DESCRIPTION
## Summary
- Block external (Slack Connect), multi-channel guest, and single-channel guest users from triggering the bot
- Check `is_restricted`, `is_ultra_restricted`, and `is_stranger` flags via `users.info` before processing any `app_mention`
- Fail-closed: deny access on API errors
- Cache auth results with 1-hour TTL; also populate name cache to avoid duplicate API calls

## What could break
- If the Slack bot token lacks `users:read` scope, all requests will be denied (fail-closed). This scope is already required for existing `resolveUserName` calls.

## How to test
1. Invite a guest or external user to a channel with the bot
2. Have them `@mention` the bot
3. Verify the bot silently ignores the message and logs a warning
4. Verify org members can still use the bot normally