### PR TITLE
Link memory repo commits to GitHub profile

### DIFF
--- a/src/memory.ts
+++ b/src/memory.ts
@@ -90,6 +90,7 @@ export function resolveMemoryDir(repo?: string): string {
       timeout: 10_000,
     });
     console.log("[memory] Registered gh credential helper for git");
+    configureGitIdentity(memoryDir);
     ensureMemoryDirs(memoryDir);
     return memoryDir;
   }
@@ -98,6 +99,27 @@ export function resolveMemoryDir(repo?: string): string {
   ensureMemoryDirs(memoryDir);
   console.log(`[memory] Using temporary directory: ${memoryDir}`);
   return memoryDir;
+}
+
+function configureGitIdentity(memoryDir: string): void {
+  try {
+    const raw = execFileSync("gh", ["api", "user", "--jq", "{id,login,name}"], {
+      encoding: "utf-8",
+      timeout: 10_000,
+    }).trim();
+    const { id, login, name } = JSON.parse(raw);
+    const gitName = name || login;
+    const gitEmail = `${id}+${login}@users.noreply.github.com`;
+    execFileSync("git", ["config", "user.name", gitName], {
+      cwd: memoryDir, encoding: "utf-8", timeout: 5_000,
+    });
+    execFileSync("git", ["config", "user.email", gitEmail], {
+      cwd: memoryDir, encoding: "utf-8", timeout: 5_000,
+    });
+    console.log(`[memory] Git identity: ${gitName} <${gitEmail}>`);
+  } catch (err) {
+    console.warn("[memory] Could not configure git identity:", (err as Error).message);
+  }
 }
 
 function ensureMemoryDirs(memoryDir: string): void {


### PR DESCRIPTION
## Summary

- Memory repo commits show as unlinked ("Claw Bot <claw@decentraland.org>") because the email doesn't match any verified email on the `regenesis-claw` GitHub account
- Added `configureGitIdentity()` that fetches the authenticated user's profile via `gh api user` and sets repo-local `user.name` and `user.email` using the noreply email format (`{id}+{login}@users.noreply.github.com`)
- No new env vars needed — derives identity from the existing `GITHUB_TOKEN`

## What could break

- If `gh api user` fails (rate limit, network), it logs a warning and continues — commits will use git defaults (current behavior)

## How to test

1. Deploy and trigger a memory save
2. Check `git -C /tmp/claw-memory log --format='%an <%ae>' -1` shows the noreply email
3. New commits on GitHub should show the regenesis-claw avatar and profile link