### PR TITLE
Cut Docker RAM footprint by running compiled dist

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,11 @@
+node_modules
+dist
+.env
+.env.*
+.auth.json
+.git
+.DS_Store
+*.log
+data
+sessions
+test

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,5 +18,11 @@ COPY src/ src/
 COPY prompts/ prompts/
 COPY skills/ skills/
 
+# Compile TypeScript to dist/ so production runs a single node process
+# instead of the 5-deep tree (npm → tsx → node → esbuild) that plain
+# `tsx src/index.ts` produces — that stack consumes ~500 MB of RSS on
+# small App Platform instances.
+RUN npm run build:dist
+
 ENTRYPOINT ["tini", "--"]
-CMD ["npx", "tsx", "src/index.ts"]
+CMD ["node", "dist/index.js"]

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "dev": "DEBUG=true tsx watch src/index.ts",
     "cli": "tsx src/cli.ts",
     "build": "tsc --noEmit",
+    "build:dist": "tsc",
     "test": "node --import tsx --test test/*.test.ts"
   },
   "dependencies": {


### PR DESCRIPTION
## Summary

DO App Platform flagged the worker at 97% RAM on a small instance. The bot itself only uses ~260 MB at runtime, but the container process tree was 5 deep — `tini → npm exec tsx → tsx → node → esbuild` — each layer a full Node process with its own V8 heap (~500 MB RSS combined).

Switch the image to run a compiled `dist/` with plain `node`. Single process. The wrappers only exist because `tsx` transpiles on the fly for dev, which we don't need in production.

## What could break

- **Runtime path resolution.** The code uses `import.meta.url` + `..` to locate `prompts/` and `skills/`. When compiled, `__dirname` becomes `/app/dist` and the `..` still resolves to `/app`, so those directories are still found. Verified by checking the computed paths in `agent.ts`.
- **Runtime regressions from compiled ESM.** `tsconfig.json` already targets `ES2022` / `ESM`, which is what `tsx` was running anyway. `dist/index.js` parses clean and tests pass against the source.
- **Slower Docker builds.** `tsc` adds a couple seconds to the build step. Worth it.

## How to test

- [ ] `npm run build` still typechecks
- [ ] `npm run build:dist` emits `dist/` without errors
- [ ] `npm test` → 73 / 73 pass
- [ ] Pull the image and `docker run --env-file .env …` — confirm startup logs look normal (memory repo clone, grants feature enabled if configured)
- [ ] After deploy, RAM on the App Platform dashboard drops from ~97% to something reasonable (expect ~20-30% on 1 GiB instance)