### PR TITLE
Normalize pandas-style ".N" duplicate CSV header suffixes

### DIFF
--- a/src/csv.ts
+++ b/src/csv.ts
@@ -78,7 +78,10 @@ export function parseCsv(text: string): CsvParseResult {
   // Google Forms exports the same question label once per conditional branch
   // (e.g. "Project title" appears in both the Content and Tech track blocks);
   // without this, the later column would silently overwrite the earlier one.
-  const rawHeaders = cells[0].map((h) => h.trim());
+  // Some exporters (pandas, Excel) pre-disambiguate duplicates with a ".1",
+  // ".2" suffix — strip those so dedupeHeaders can re-emit the canonical "(N)"
+  // form and downstream lookups stay schema-stable.
+  const rawHeaders = cells[0].map((h) => h.trim().replace(/\.\d+$/, ""));
   const headers = dedupeHeaders(rawHeaders);
   const rows: CsvRow[] = cells
     .slice(1)

--- a/test/csv.test.ts
+++ b/test/csv.test.ts
@@ -147,6 +147,22 @@ test("parseCsv: disambiguates duplicate headers with (N) suffix", () => {
   assert.equal(parsed.rows[0]["Project title (2)"], "Beta");
 });
 
+test("parseCsv: normalizes pandas-style .N suffix to canonical (N) form", () => {
+  // Some exporters (pandas, Excel) pre-disambiguate duplicates as "Foo.1".
+  // Normalize to the canonical "(2)" form so downstream lookups stay stable.
+  const parsed = parseCsv("Project title,Budget,Project title.1\nAlpha,100,Beta");
+  assert.deepEqual(parsed.headers, ["Project title", "Budget", "Project title (2)"]);
+  assert.equal(parsed.rows[0]["Project title (2)"], "Beta");
+});
+
+test("parseCsv: .1/.2 suffixes collapse and re-emit as (2)/(3)", () => {
+  const parsed = parseCsv("Q,Q.1,Q.2\na,b,c");
+  assert.deepEqual(parsed.headers, ["Q", "Q (2)", "Q (3)"]);
+  assert.equal(parsed.rows[0]["Q"], "a");
+  assert.equal(parsed.rows[0]["Q (2)"], "b");
+  assert.equal(parsed.rows[0]["Q (3)"], "c");
+});
+
 test("formatCsvAsProposal: strips (N) suffix from display labels", () => {
   const parsed = parseCsv("Project title,Project title\nAlpha,Beta");
   const output = formatCsvAsProposal(parsed, "x.csv");

--- a/test/proposal-template.test.ts
+++ b/test/proposal-template.test.ts
@@ -121,6 +121,38 @@ test("renderProposalTopic: no category collapses to just project title", () => {
   assert.match(out!.body, /# \[Grant Proposal\] Barebones\n/);
 });
 
+test("renderProposalTopic: end-to-end with pandas-style .N duplicates (semicolon delimiter)", () => {
+  // New Google Form export shape: semicolon delimiter + ".1" suffix on duplicate
+  // headers (instead of literal duplicates). The Tech-track fields land in the
+  // ".1" columns, so projectTitle/whatIs/etc. must still resolve.
+  const csv =
+    `Timestamp;Who is applying?;Full name or studio / company name;Primary contact person;` +
+    `Which category are you applying to?;Project title;What is the project?;` +
+    `What would be delivered within 90 days?;How would you measure success?;` +
+    `What kind of technical proposal are you submitting?;Project title.1;What is the project?.1;` +
+    `How does this proposal align with the AI-assisted tooling theme?;Who would use this tool or system?;` +
+    `What problem does this solve?;What would be delivered within 90 days?.1;` +
+    `How would this be shared as open-source work?;How would you measure success?.1;` +
+    `What is your estimated funding request in USD?\n` +
+    `01/04/2026;Individual;Mohammed Zaid;Mohammed Zaid;Tech Ecosystem — AI-assisted tooling;;;;;` +
+    `A library, integration, or infrastructure component;SITR Protocol;ZK private MANA payments;` +
+    `Solves privacy.;DCL devs.;Public on-chain history.;- ZK circuit;Open source MIT.;- 10 mainnet txs;13000`;
+  const parsed = parseCsv(csv);
+  assert.equal(parsed.rows.length, 1);
+  // Confirm the .1 suffix got normalized to canonical (2)
+  assert.ok(parsed.headers.includes("Project title (2)"));
+  assert.ok(parsed.headers.includes("What is the project? (2)"));
+
+  const out = renderProposalTopic(parsed.rows[0]);
+  assert.ok(out);
+  assert.equal(out!.title, "SITR Protocol — Tech Ecosystem");
+  assert.match(out!.body, /ZK private MANA payments/);
+  assert.match(out!.body, /## Budget — \$13000/);
+  assert.match(out!.body, /AI-assisted tooling theme/);
+  assert.match(out!.body, /- ZK circuit/);
+  assert.match(out!.body, /- 10 mainnet txs/);
+});
+
 test("renderProposalTopic: end-to-end with the real sample CSV", () => {
   const csv = `Timestamp,Applying for,I understand that proposals must align with the selected category theme for this season,Who is applying?,Full name or studio / company name,Primary contact person,Email address,Decentraland Forum Username,Country or region,"Website, portfolio, or company page","X, LinkedIn, GitHub, or other relevant profile",How many people would actively work on this project?,Tell us about the team behind this proposal,What relevant skills or expertise does your team bring?,What best describes your current relationship with Decentraland?,Have you or your team previously shipped anything in Decentraland?,"If yes, tell us what you built in Decentraland",Why do you want to build this for Decentraland?,What similar projects have you or your team built before?,Links to relevant past work,How confident are you that your team can deliver this project within 90 days?,Which category are you applying to?,What kind of content proposal are you submitting?,Project title,What is the project?,How does this proposal embody the Mobile-first experiences theme?,"If this is based on an existing experience, share the link",What will users actually do in the experience?,Who is this experience for?,Why would this improve Decentraland?,What would be delivered within 90 days?,How would you measure success?,What kind of technical proposal are you submitting?,Project title,What is the project?,How does this proposal align with the AI-assisted tooling theme?,Who would use this tool or system?,What problem does this solve?,What would be delivered within 90 days?,How would this be shared as open-source work?,How would you measure success?,What is your estimated funding request in USD?,How did you estimate this budget?,What are the main milestones you expect across the 90-day period?,Is this project also receiving funding from another source?,"If yes, please explain",Upload or link a visual project overview,"Repository, prototype, or technical documentation",Is there anything else you would like us to know?,I confirm that the information submitted here is accurate to the best of my knowledge,I understand that the program is intended to support open-source work,I understand that DCL Regenesis Labs may contact me for follow-up questions or clarifications during review
 01/04/2026 18:17:22,I understand and confirm,I understand and confirm,Studio/Company,CoBuilders,Lautaro Sole,lautaro@cobuilders.xyz,https://forum.decentraland.org/u/pollodumas,Uruguay,cobuilders.xyz,http://github.com/CoBuilders-xyz,3,"We are CoBuilders.","Node.js and TypeScript.",External studio,No,,Open architecture.,Similar work.,https://example.com,Very confident,Tech Ecosystem — AI-assisted tooling,,,,,,,,,,,"Library",AI Scene Controller,"A self-deployable AI orchestration system.","AI is central.","DCL developers.","Scenes are limited.","- Orchestrator","Released on GitHub.","- Deployments",15000,Engineering time.,"Phase 1",No,,,https://cobuilders.notion.site,"Extra notes.",I confirm,I understand,I understand`;


### PR DESCRIPTION
## Summary

The new Google Form / pandas-style CSV exports disambiguate duplicate column names with a `.1` / `.2` suffix instead of literal duplicates (e.g. `Project title.1` rather than a second `Project title`). Tech-track proposals land in those `.N` columns, so `proposal-template.ts` lookups for `"Project title (2)"` resolved to empty and Discourse topics were created without a title, description, deliverables, or success metrics.

Strip `\.\d+$` from raw headers before `dedupeHeaders` runs so the canonical `(N)` form is re-emitted. All downstream callers (`proposal-template.ts`, `BUREAUCRACY_HEADERS`, `formatCsvAsProposal` display) keep working unchanged.

## What could break

- A real form question whose header literally ends in `.<digit>` (e.g. `"Version 1.1"`) would lose the trailing number. None of the current Google Form columns end this way; if it ever happens we can tighten the rule to only strip when the un-suffixed form already exists in the header set.
- Legacy literal-duplicate exports still work (the regex is a no-op when there's no `.\d+$` suffix); `dedupeHeaders` runs after either way.

## How to test

- [ ] `npm test` — 78 tests pass, including 3 new ones covering `.N` normalization and the SITR-shape end-to-end render.
- [ ] `npm run build` — clean.
- [ ] Drop the SITR CSV (`23-sitr-protocol-private-mana-payment-infrastructure-for-decentraland (1).csv`) into the grants channel and confirm the Discourse topic title is `SITR Protocol — Private MANA Payment Infrastructure for Decentraland — Tech Ecosystem` (not `Grant Proposal — Tech Ecosystem`) and the body has the project description, deliverables, milestones, and success metrics populated.