### PR TITLE
docs: agent-server comparison + Path A implementation plan

### DIFF
--- a/docs/claw-bot-vs-agent-server-comparison.md
+++ b/docs/claw-bot-vs-agent-server-comparison.md
@@ -1,0 +1,161 @@
+# Slack AI Agents — `slack-claw-bot` vs `agent-server`
+
+**Comparison & migration recommendation for Regenesis Labs**
+Prepared: 2026-06-03 · Sources: `dcl-regenesislabs/slack-claw-bot@main`, `decentraland/agent-server@main`
+
+---
+
+## TL;DR
+
+Both bots are **siblings forked from the same base** (same Slack-Bolt socket-mode shell, the same `@mariozechner/pi-coding-agent` engine, the same OAuth `.auth.json` flow, and an overlapping set of generic skills: `create-issue`, `github`, `pr-review`, `repos`, `triage`, `mobile-project`). They then diverged toward two very different owners:
+
+- **`slack-claw-bot`** is the **Regenesis Labs** fork. Its distinctive value is the **Grants Agents** pipeline (VOXEL / CANVAS / LOOP / SIGNAL / ORACLE) with Discourse publishing and CSV intake, plus a **git-backed, searchable memory** system and **runtime skill creation**. It is smaller and simpler (~3.6k LOC).
+- **`agent-server`** is the **Decentraland Foundation** fork (internally still nicknamed "Jarvis"). It is a larger platform (~4.7k LOC, ~40 skills) with a **pluggable agent backend** (Claude CLI *or* pi-agent), **cron scheduling**, **sub-agents**, **DM + auto-reply routing**, **Prometheus metrics**, and a deep catalog of **Decentraland-Foundation-infrastructure skills** (AWS, ECS, Sentry, Grafana, GitLab, LiveKit, events moderation, credits, feature flags…).
+
+**Recommendation: Path A — keep `slack-claw-bot` as the home and selectively port a short list of org-agnostic capabilities from `agent-server`.** Adopting `agent-server` wholesale (Path B) means inheriting a large surface that is hard-wired to the Decentraland Foundation Slack org and infrastructure — and you'd still have to re-implement the Grants pipeline and git memory, which `agent-server` does not have. The cross-org reality (different Slack workspace) is the deciding factor; see [§5](#5-the-cross-org-problem-the-deciding-factor).
+
+---
+
+## 1. Shared lineage (what's identical)
+
+| Aspect | Both bots |
+|---|---|
+| Transport | Slack Bolt, Socket Mode, `app_mention` subscription |
+| Agent engine | `@mariozechner/pi-coding-agent` (pi-agent) |
+| Auth model | Anthropic **OAuth only** (no API key); `.auth.json` source of truth; refresh-token rotation; Upstash/Redis persistence |
+| Concurrency | Bounded `AgentScheduler` pool with queue + graceful `drain()` |
+| Skills | File-based `skills/*/SKILL.md`, prompt-injected; shared core: `create-issue`, `github`, `pr-review`, `repos`, `triage`, `mobile-project` |
+| Prompt builder | Extracted `prompt.ts` for testability |
+| PR-review model | Always forced to `claude-opus-4-6` regardless of `MODEL` |
+| Session continuity | One session per Slack thread, resumes instead of re-reading |
+| CLI harness | `cli.ts` REPL + one-shot + `--dry-run` for local testing |
+| Health endpoint | `GET /health/live` |
+
+Because the foundations are identical, **porting code between them is low-friction** — the interfaces (`RunOptions`, `runAgent`, scheduler, prompt builder) line up almost one-to-one. This is what makes Path A cheap.
+
+---
+
+## 2. Capability matrix
+
+| Capability | `slack-claw-bot` (Regenesis) | `agent-server` (DCL Foundation) |
+|---|---|---|
+| **Agent backend** | pi-agent only | **Pluggable**: Claude CLI (`claude -p`) *or* pi-agent, selected by `AGENT_BACKEND` |
+| pi-agent version | `^0.67.6` (**newer**) | `^0.55.0` (older) |
+| **Two-account failover** | ✗ (single account + Redis) | ✓ primary + fallback account, auto-retry on 429/401/403 (both backends) |
+| Auth resilience | Basic load/seed/sync | **Hardened**: seed-change detection, 3× startup probe, periodic auth health check, rate-limit interceptor + `@bot status` |
+| **Memory** | **Git-backed repo** (`MEMORY_REPO`): `shared/` + per-`user/` + `daily/`, **qmd BM25 search**, atomic writes | **S3-backed** single `global-context.md` (auto-compressed) + per-interaction summaries; public channels only; no search, no per-user files |
+| **Runtime skill creation** | ✓ agent writes new skills to memory repo, `push-memory` | ✗ |
+| **Sub-agents** | ✗ | ✓ discovers personas (compound-engineering), runs ≤4 in parallel, read-only vs coding tools; exposed to CLI backend via **MCP server** |
+| **Cron scheduling** | ✗ | ✓ `croner` runner, **S3-persisted** (survives deploys), posts results to channels, `schedule` skill for conversational setup |
+| Slack triggers | `app_mention` only | `app_mention` + **DMs** + **auto-reply channels** (`channelId:skill` bindings, static + env) |
+| Image input | ✓ | ✓ |
+| **Observability** | console logs + health | **Prometheus metrics**, `@well-known-components` Lifecycle, structured logger |
+| **Grants Agents pipeline** | ✓✓ **VOXEL/CANVAS/LOOP/SIGNAL/ORACLE**, separate scheduler, per-proposal state | ✗ |
+| **Discourse publishing** | ✓ multi-user impersonation, verbatim posting | ✗ |
+| CSV proposal intake | ✓ server-side parse + normalize | ✗ |
+| Notion (Shape Up) | ✗ | ✓ `shape:` → Notion pitch page |
+| Tool write-guard | ✓ protects own `src/` from edits | ✓ via workspace `CLAUDE.md` + prompt rules |
+| Skill count | 9 (mostly generic) | ~40 (mostly DCL-infra-specific) |
+| Tests | `node:test`, 7 files | Jest + coverage, 18 files |
+| Runtime / pkg mgr | Node 20+, npm | Node 24 (engines ≥20), yarn |
+| Default model | `claude-sonnet-4-5` | `claude-sonnet-4-6` |
+
+---
+
+## 3. Architecture differences that matter
+
+### 3.1 Backend abstraction (`agent-server` is more flexible)
+`agent-server` defines an `AgentBackend` interface with two implementations:
+- **CLI backend** — spawns the `claude -p` subprocess with stream-JSON parsing, per-session isolated workspaces (`data/sessions/<uuid>/`), MCP wiring, and a deterministic UUIDv5 mapping from Slack thread TS → session id. Auth is a long-lived (~1yr) `setup-token` that doesn't rotate (no Redis needed).
+- **pi-agent backend** — the original in-process flow (same as claw-bot).
+
+`slack-claw-bot` only has the in-process pi-agent path. The CLI backend is attractive because the long-lived token removes the refresh-rotation/Redis fragility, and it gets you Claude Code's native skills/subagents/MCP for free — **but** it requires the `claude` CLI present in the container and bumps the runtime story in complexity.
+
+### 3.2 Memory (claw-bot is actually *more* capable here)
+This is counter-intuitive given `agent-server`'s size: claw-bot's memory is **richer**. It is a real git repo with shared/user/daily separation, **keyword search (qmd)**, atomic state files, and the ability for the agent to **author new skills at runtime**. `agent-server` keeps a single auto-compressed `global-context.md` in S3 plus per-thread summaries — simpler, public-channel-only, no search, and tied to an S3 component (DCL infra). **If you adopt `agent-server`, you lose memory capability** unless you port claw-bot's system over.
+
+### 3.3 Sub-agents & scheduling (agent-server wins)
+`agent-server`'s `subagent.ts` is a genuine fan-out primitive: it discovers agent personas, runs up to 4 in parallel with per-agent tool scoping (read-only vs coding) and timeouts, and exposes the whole thing to the CLI backend through a stdio **MCP server** (`mcp-subagent.ts`). Its `pr-review`, `plan`, and `workflows-*` skills lean on this. Combined with the **S3-persisted cron scheduler**, these are the two most valuable org-agnostic things claw-bot lacks.
+
+> Note: claw-bot's Grants pipeline is *conceptually* a multi-agent system too, but it's a bespoke orchestrator (one session per persona), not the generic, reusable `subagent` tool `agent-server` exposes to the model.
+
+### 3.4 Operational maturity (agent-server wins)
+`agent-server` uses the `@well-known-components` framework (Lifecycle, http-server, metrics, logger), Prometheus metrics, commit-signing key handling, manual-deploy workflow, and `.claude/hooks`. claw-bot is a plainer `tsx`-run process. For a small team this is a wash until you need dashboards/alerting.
+
+---
+
+## 4. What's exclusive to each
+
+**Only in `slack-claw-bot` (your crown jewels):**
+- Grants Agents (5-persona evaluation) + per-proposal state machine + separate scheduler
+- Discourse multi-user publishing + CSV intake/normalization
+- Git-backed searchable memory + runtime skill authoring
+- Newer pi-agent (`0.67.6` vs `0.55.0`)
+
+**Only in `agent-server` (and mostly DCL-specific):**
+- *Org-agnostic & worth porting:* CLI backend, two-account failover, auth health/rate-limit, **cron scheduling**, **sub-agents/MCP**, DM + auto-reply routing, Prometheus metrics, Notion Shape Up, `fix`/`plan`/`security-review`/`refine-context`/`workflows-*` skills.
+- *DCL-Foundation-bound (not portable):* `aws-infra`, `ecs-alert`, `sentry`, `grafana`, `data-query`, `livekit`, `feature-flags`, `events-approval`, `credits-unban`, `dcl-ban-check`, `dcl-consistency`, `ab-status`/`ab-reconvert`, `places-featured`, `release-review`, `sites-*`, `explorer-project`, `incident`, `pipeline` (GitLab `dcl.tools`), `update-faq`.
+
+---
+
+## 5. The cross-org problem (the deciding factor)
+
+**Regenesis Labs runs a different Slack workspace than the Decentraland Foundation.** `agent-server` is bound to the Foundation's org and infra in ways that don't travel:
+
+1. **Hardcoded Slack user IDs.** Authorization allowlists and escalation pings are baked into skill markdown as literal `U…` IDs — e.g. `credits-unban`, `ab-reconvert`, `events-approval`, `places-featured`, `release-review`. In a different org these IDs are **wrong or non-existent**: the bot would gate on phantom users and `@mention` strangers. (`release-review` even has a hardcoded "Regenesis Lab" trio — `U097SSTNBUM`, `U092VG21JJU`, `U092R02ML72` — confirming the IDs are Foundation-workspace-scoped.)
+2. **Hardcoded channel IDs.** Auto-reply is wired to `C010J8JQSUB` (Foundation `#events`) in `service.ts`; the zone channel `C01MRMAFPG8` is special-cased. None of these exist in your org.
+3. **Foundation-only infrastructure.** AWS cross-account `InfraReader-AgentServer` roles, GitLab `dcl.tools`, the `@dcl/jarvis` service catalog, `decentraland.org/.zone` events APIs + admin tokens, `comms-gatekeeper`, `@dcl/opscli`, Cloudflare feature-flag worker, `playbooks.decentraland.systems`. Regenesis has no access to these, so ~20 skills are dead weight.
+4. **Secrets surface.** `agent-server` expects a long list of Foundation tokens (`EVENTS_ADMIN_AUTH_TOKEN_*`, `COMMS_MODERATOR_TOKEN`, `GITLAB_TOKEN_*`, `CF_*`, `LIVEKIT_*`, `SENTRY_*`…). You'd carry the config complexity for capabilities you can't use.
+
+The skills are env-flagged, so the dead ones won't *fire* without tokens — but the **hardcoded IDs are the real hazard** (silent mis-authorization / wrong pings), and every Foundation skill you keep is maintenance you don't benefit from and a divergence point from upstream.
+
+---
+
+## 6. Two paths
+
+### Path A — Uplift `slack-claw-bot` (recommended)
+Keep claw-bot as the product. Port a curated shortlist from `agent-server`. Because both share the same engine and interfaces, each port is a contained change.
+
+**Suggested order (highest value / lowest risk first):**
+1. **Cron scheduling** — port `service.ts` schedule runner + `schedule` skill. Swap S3 persistence for **your existing git-backed memory repo** (write `schedules.json` there) so you add no new infra. *High value, self-contained.*
+2. **Sub-agents** — port `subagent.ts` as a pi-agent tool (you don't need the MCP layer unless/until you adopt the CLI backend). Wire `pr-review`/`plan` to use it.
+3. **Two-account failover + auth health/rate-limit + `@bot status`** — port from `agent/shared.ts` + `agent.ts`. Pure resilience, no org coupling.
+4. **DM + auto-reply routing** — port the Slack handler additions; define channel→skill bindings for *your* channels.
+5. **Optional:** `fix`, `plan`, `security-review`, `workflows-*`, `refine-context` skills (org-agnostic); Notion Shape Up if you use Notion; Prometheus metrics if you want dashboards.
+6. **Skip:** every DCL-infra skill in [§4](#4-whats-exclusive-to-each).
+
+**Pros:** keeps Grants + git memory + runtime skills; no wasted surface; you own all Slack IDs from day one; incremental and reversible; stays on the newer pi-agent.
+**Cons:** you do the backporting and own the result (no upstream to pull from).
+
+### Path B — Adopt `agent-server` in Regenesis
+Fork `agent-server`, then: strip/disable all DCL-infra skills, **rewrite every hardcoded `U…`/`C…` ID** to your org, remove Foundation env/secrets, and **re-implement the Grants pipeline + git memory + runtime skills** on top (neither exists upstream).
+
+**Pros:** you start from the richer platform (dual backend, scheduling, sub-agents, metrics, auto-reply) without building them.
+**Cons:** large, error-prone surgery (the hardcoded-ID hazard is exactly where bugs hide); you still must rebuild your crown-jewel features; ongoing divergence from a fast-moving upstream you can't cleanly track; older pi-agent. Net effort is **higher** than Path A for a worse identity fit.
+
+---
+
+## 7. Recommendation
+
+**Take Path A.** The asymmetry is decisive:
+
+- Your differentiators (**Grants Agents, Discourse, git-backed searchable memory, runtime skills**) live *only* in claw-bot and would have to be rebuilt under Path B.
+- The genuinely valuable, portable wins from `agent-server` are a **short, tractable list** (scheduling, sub-agents, auth resilience, DM/auto-reply) — all of which drop cleanly onto claw-bot's identical foundation.
+- ~Half of `agent-server`'s surface is **Decentraland-Foundation-infrastructure** that Regenesis can't use, and its **hardcoded Slack IDs** make a wholesale adoption actively risky in a different workspace.
+
+Sequence the four Path-A ports in [§6](#path-a--uplift-slack-claw-bot-recommended); the first three carry no org coupling and can ship independently. Revisit the **CLI backend** only if/when token-rotation fragility or native Claude-Code skills/MCP become a real pain — it's the one larger architectural bet worth keeping on the radar.
+
+---
+
+## Appendix — quick facts
+
+| | claw-bot | agent-server |
+|---|---|---|
+| Repo | `dcl-regenesislabs/slack-claw-bot` | `decentraland/agent-server` |
+| src LOC | ~3,566 | ~4,679 |
+| Skills | 9 | ~40 |
+| Test files | 7 (`node:test`) | 18 (Jest + coverage) |
+| Pkg mgr / Node | npm / 20+ | yarn / 24 |
+| pi-agent | `^0.67.6` | `^0.55.0` |
+| Persistence infra | Upstash Redis + git memory repo | Redis + **S3** (memory, schedules) |
+| Default model | `claude-sonnet-4-5` | `claude-sonnet-4-6` |

--- a/docs/path-a-implementation-plan.md
+++ b/docs/path-a-implementation-plan.md
@@ -1,0 +1,177 @@
+# Path A — Implementation Plan
+
+**Uplift `slack-claw-bot` with org-agnostic capabilities from `agent-server`**
+Prepared: 2026-06-03 · Companion to `claw-bot-vs-agent-server-comparison.md`
+
+---
+
+## Guiding principles
+
+1. **Reuse the git-backed memory repo as the only persistence layer.** `agent-server` uses S3 for schedules/stats; claw-bot already clones/pulls a git memory repo on startup (`resolveMemoryDir`) and the agent commits via the `push-memory` skill. We piggyback on that — **no new infra (no S3) is introduced.**
+2. **Additive, not invasive.** Each port lands behind a feature flag (env var) and degrades to current behavior when unset. Ports 1, 2, and 4 are largely additive; Port 3 is the one real refactor and is staged.
+3. **Each port ships independently** in the order below. Ports 1–2 and 4 carry zero org coupling; do them first.
+4. **Stay on claw-bot's newer pi-agent (`0.67.6`).** All ported code uses the same `@mariozechner/pi-coding-agent` API claw-bot already imports.
+
+### Contract reminders (claw-bot, current)
+- Entry point `src/index.ts` (top-level await): `loadConfig()` → `initAgent()` → `createScheduler()` → `createSlackApp(config, scheduler, () => grantsRouter)` → `startSlackApp(app)`; SIGTERM/SIGINT → `app.stop()` + `scheduler.drain(20_000)`.
+- `runAgent(options)` (in `agent.ts`) **always** builds its prompt from `fetchThread()`/`fetchThreadSince()` unless a `sessionManager` is supplied. It supports overrides we'll lean on: `sessionManager`, `systemPrompt`, `skipMemorySave`, `skipMemoryLoad`, `additionalSkillPaths`, `tools`. Returns `{ text, cost, tokens, done }` where `done` is the background memory-save promise.
+- `AgentScheduler.submit(threadId, work)` / `.drain(ms)` (in `concurrency.ts`) — reused as-is.
+- Auth is a single module-level `authStorage` seeded from `ANTHROPIC_OAUTH_REFRESH_TOKEN`, persisted to Upstash Redis (REST).
+
+---
+
+## Port 1 — Cron scheduling (git-backed) ⭐ do first
+
+**Goal:** users create recurring tasks conversationally (`@bot schedule daily 9am: post yesterday's merged PRs to #eng`); a runner fires due tasks and posts results to a channel. Schedules survive restarts via the **git memory repo**, not S3.
+
+### New file: `src/schedule.ts`
+Port `agent-server/src/service.ts` lines 127–416, with these changes:
+- **Storage path:** `join(memoryDir, "schedules", "schedules.json")` and `…/schedule-stats.json` (instead of `data/…`). Both live inside the cloned memory repo.
+- **Persistence:** delete all `IS3Component` code (`syncToS3IfChanged`, `debounceSync`, `watchFile`, S3 restore). Durability is handled two ways:
+  - *Restart restore* — free: `resolveMemoryDir` already `git pull --rebase`es on startup, so `schedules.json` is present.
+  - *Write-through* — when the **`schedule` skill** mutates the file it then runs `push-memory` (commit+push), exactly like other memory writes. The runner does **not** need to push.
+- **Keep:** the `Cron` (croner) due-time logic, the `NO_OUTPUT` sentinel, the per-schedule `AgentScheduler(1)` lane, stats in a separate file (race-avoidance), and the 60s tick.
+- **Runner → agent bridge:** `agent-server` calls `runAgent({ threadContent, triggeredBy })`. claw-bot's `runAgent` has no `threadContent`, so invoke it in the grants-style "raw prompt" mode:
+  ```ts
+  const { text, done } = await runAgent({
+    threadTs: `schedule-${schedule.id}`,
+    eventTs: String(Date.now() / 1000),
+    userId: "scheduler", username: "scheduler",
+    newMessage: schedule.task,
+    fetchThread: async () => schedule.task,        // no Slack thread to read
+    fetchThreadSince: async () => "",
+    sessionManager: SessionManager.inMemory(),     // bypass resolveSession
+    triggeredBy: `schedule:${schedule.id}`,
+    skipMemorySave: true, skipMemoryLoad: true,    // v1: don't touch bot memory
+  });
+  await done;
+  ```
+  Post `text` to `schedule.channel` via `chat.postMessage` (reuse the existing bot token), skipping when it starts with `NO_OUTPUT`. Truncate >3000 chars + append the `_Schedule: … · cron · ID_` footer (kept from the source).
+
+### New file: `skills/schedule/SKILL.md`
+Port `agent-server/skills/schedule/SKILL.md`, adapting the storage description to the git path and `push-memory` step. The skill teaches the agent to read/create/list/delete entries in `schedules.json` (id, cron, task, description, channel, createdBy, createdAt, enabled) and to call `push-memory` after any mutation.
+
+### Edits
+- `src/index.ts`: after `startSlackApp(app)`, `const scheduleRunner = await startScheduleRunner({ slackBotToken, memoryDir });` (guard on `memoryDir` — feature requires the git memory repo). In `shutdown()`, add `scheduleRunner.stop()` and `await scheduleRunner.drain(15_000)`.
+- `src/config.ts`: no new env required (path derives from `MEMORY_REPO`). Optionally add `SCHEDULES_ENABLED` to force-disable.
+
+### Tests: `test/schedule.test.ts`
+Port the relevant cases from `agent-server/test/unit/schedule-*.spec.ts` (cron due-time math, stats isolation, `NO_OUTPUT` suppression), dropping S3 assertions. Use a temp dir for `memoryDir`.
+
+**Effort:** ~0.5–1 day. **Org coupling:** none. **Risk:** low (isolated runner + own scheduler lane).
+
+---
+
+## Port 2 — Sub-agent fan-out tool
+
+**Goal:** give the model a `subagent` tool that delegates to specialized personas running in parallel isolated sessions (read-only vs coding tools), so `pr-review`/`plan`-type skills can fan out research. (Distinct from the bespoke Grants orchestrator — this is the generic, model-callable primitive.)
+
+### New file: `src/subagent.ts`
+Port `agent-server/src/subagent.ts` **almost verbatim** (`discoverAgents`, `resolveModel`, `runSingleAgent`, `runWithConcurrency`, `createSubagentTool`). It already uses the same lib (`createAgentSession`, `createReadOnlyTools`, `createCodingTools`, `SessionManager.inMemory`, `parseFrontmatter`). Update `resolveModel`'s short-name map to claw-bot's defaults (`sonnet → claude-sonnet-4-5`, keep `opus → claude-opus-4-6`, `haiku → claude-haiku-4-5`).
+
+### New dir: `agents/` (persona definitions)
+`agent-server` discovers personas from `@every-env/compound-plugin` (a dependency claw-bot does **not** have). Don't add that dep — instead create a small local `agents/` dir with frontmatter persona files, e.g.:
+- `agents/repo-research-analyst.md` (tools: `read, grep, bash` → read-only)
+- `agents/code-reviewer.md`
+- `agents/best-practices-researcher.md`
+
+Each: `name`, `description`, optional `model`, optional `tools` (CSV; read-only if only read/grep/find/ls/bash). Resolve `agentsDir = join(projectDir, "agents")`.
+
+### Edits: `src/agent.ts`
+In `createSession()`, build the tool and pass it as `customTools` (claw-bot currently passes only `tools`; the lib accepts `customTools` too — `agent-server`'s pi backend uses both):
+```ts
+const subagentTool = createSubagentTool({
+  agentsDir: join(projectDir, "agents"),
+  authStorage: authStorage!,
+  modelRegistry,                 // already built a few lines above
+  parentModelId: modelId,
+});
+return createAgentSession({ …, tools: toolsOverride ?? createGuardedTools(cwd), customTools: [subagentTool] });
+```
+Guard: skip the subagent tool when `toolsOverride` is `[]` (grant agents run tool-less) to preserve their no-side-effect contract.
+
+### Tests: `test/subagent.test.ts`
+Port `agent-server/test/unit/subagent.spec.ts` (agent discovery, unknown-agent handling, read-only vs coding tool selection, concurrency cap).
+
+**Effort:** ~1 day. **Org coupling:** none. **Risk:** low-medium (extra parallel sessions consume tokens; the `MAX_CONCURRENCY=4` + 7-min timeout from the source cap this). **Note:** the MCP layer (`mcp-subagent.ts`/`workspace.ts`) is **only** needed for the CLI backend — skip it unless/until Port 3b (CLI backend) is pursued.
+
+---
+
+## Port 3 — Two-account failover + auth health + rate-limit status (staged)
+
+This is the **only real refactor**: claw-bot's `agent.ts` is monolithic (single `authStorage`, session execution inline in `runAgent`), whereas `agent-server` split it into a router (`agent.ts`) + `agent/shared.ts` + `agent/pi/index.ts`. Stage it so value lands early and the risky part is last.
+
+### 3a — Rate-limit interceptor + `@bot status` (additive, low risk) — do first
+- New file `src/agent-shared.ts`: port `agent-server/src/agent/shared.ts` **verbatim** (rate-limit snapshot, fetch interceptor, `buildRateLimitWarning`, `_isAuthError`, `_logDrainedErrors`, session-label `AsyncLocalStorage`). It's self-contained and backend-agnostic.
+- `agent.ts`: call `_installRateLimitInterceptor()` at the end of `initAgent()`; append `buildRateLimitWarning()` to the `runAgent` result text. Add `getStatusMessage()` (port from `agent-server/src/agent.ts` lines 128–158, using claw-bot's `modelId`).
+- `slack.ts`: in the `app_mention` handler, short-circuit when the stripped text is `status` → `say(getStatusMessage())` (no agent run), mirroring `agent-server`'s `@bot status`.
+
+### 3b — Fallback account (medium risk) — do second
+- `config.ts`: add `fallbackOAuthRefreshToken` (`FALLBACK_ANTHROPIC_OAUTH_REFRESH_TOKEN`).
+- `agent.ts`: add a second module-level `fallbackAuthStorage` seeded/loaded the same way as primary (extend `loadAuth` into a small `initAuthSlot` helper; persist fallback under a distinct Redis key `anthropic_auth_fallback`). claw-bot's Redis is the Upstash REST shim in `agent.ts` — add a `key` param to `redisGet`/`redisSet`.
+- Wrap the **main answer** execution with primary→fallback retry, modeled on `agent-server/src/agent/pi/index.ts::run`:
+  - extract `session.prompt(prompt)` + result inspection into an `executeAttempt(authStorage)` closure inside `runAgent`;
+  - on a returned `429` **or** a thrown auth error (`_isAuthError`), dispose and re-run `executeAttempt(fallbackAuthStorage)` once.
+  - **Decision needed (see below):** keep memory-save bound to the account that produced the answer; simplest v1 is to run the post-task memory save on the *successful* session only.
+
+### 3c — Periodic auth health check (low risk) — do last
+- Port `startAuthHealthCheck()`/`probeAuth()` from `agent-server/src/agent.ts` (lines 436–507), reduced to claw-bot's slots. Call it from `index.ts` after `initAgent`. `unref()` the timer so it never blocks shutdown.
+
+### Tests
+Port `agent-server` `auth-resilience.spec.ts`, `prompt`/rate-limit cases, and the `_resolveAuthSource`/`_validateAuthProbe` unit tests (adapt to claw-bot's single→dual slot shape). Use `NODE_ENV=test` guards already present in the source.
+
+**Effort:** ~2–3 days total (3a ≈ 0.5d, 3b ≈ 1.5d, 3c ≈ 0.5d). **Org coupling:** none. **Risk:** 3b is the delicate part — it touches the core run path and the memory-save handoff. Land 3a/3c independently first.
+
+---
+
+## Port 4 — DM + auto-reply channel routing
+
+**Goal:** respond in DMs (not just `@mention`), and optionally auto-reply to top-level messages in designated channels bound to a skill.
+
+### 4a — DMs (clear value, do first)
+- `slack.ts`: add an `app.message` handler. Filter to `event.channel_type === "im"`, ignore bot/self messages (`subtype`/`bot_id`) and message edits. Reuse the **exact** `scheduler.submit → runAgent → say` pipeline from the `app_mention` handler (extract it into a shared `handleUserTurn({ text, channel, threadTs, eventTs, user, client, say, files })` to avoid duplication). Keep the existing `isExternalOrGuest` gate — DMs from guests/external should be denied too.
+- No new env. Requires the Slack app to subscribe to `message.im` and have the `im:history` scope (document in README).
+
+### 4b — Auto-reply channels (do second)
+- `config.ts`: add `autoReplyChannels: Map<string,string>` parsed from `AUTO_REPLY_CHANNEL_IDS` (`C…:skill,C…:skill`). Unlike `agent-server`, **do not** ship a `STATIC_AUTO_REPLY_CHANNELS` list of foreign channel IDs — Regenesis channels are configured per-deploy via env only.
+- `slack.ts`: in the `message` handler, when `event.channel` is in `autoReplyChannels` and it's a top-level message, run the agent with `additionalSkillPaths`/a directive pointing at the bound skill, and pass the channel context. claw-bot's `prompt.ts` doesn't currently inject `channelId` — add an optional `channelId` arg to `buildPrompt` (mirrors `agent-server`'s `RunOptions.channelId`) so skills can branch on env.
+- Optional pre-gating (only if a future skill needs it): port the pattern in `agent-server/src/skill-filters.ts` (cooldown/dedup/debounce) — **skip for v1**; it exists to tame DCL webhook traffic you don't have.
+
+### Tests: extend `test/slack.test.ts`
+DM routing, self/bot-message ignore, external-user denial in DMs, auto-reply channel match + skill binding parse.
+
+**Effort:** ~1–1.5 days (4a ≈ 0.5d, 4b ≈ 1d). **Org coupling:** none (you own the channel IDs). **Risk:** low-medium — guard hard against bot-loops (ignore bot/self messages) to avoid runaway auto-replies.
+
+---
+
+## Cross-cutting changes
+
+- **`.env.example`**: add `FALLBACK_ANTHROPIC_OAUTH_REFRESH_TOKEN`, `AUTO_REPLY_CHANNEL_IDS`, (optional) `SCHEDULES_ENABLED`. No S3 vars.
+- **`README.md` / `CLAUDE.md`**: document the four new capabilities; add Slack scopes for DMs (`im:history`, `message.im` event); note schedules live in the memory repo.
+- **`package.json`**: add `croner` (Port 1). Everything else uses existing deps. **Do not** add `@dcl/s3-component`, `@dcl/jarvis`, `@every-env/compound-plugin`, `@well-known-components/*`, or `@anthropic-ai/claude-code` (those are agent-server/DCL-specific).
+- **System prompt (`prompts/system.md`)**: add a short note about `subagent` availability and the `schedule` skill, mirroring `agent-server`'s "mandatory skill usage" style but only for the skills you ported.
+
+---
+
+## Sequencing & effort
+
+| # | Port | Effort | Org coupling | Risk | Ship gate |
+|---|------|--------|--------------|------|-----------|
+| 1 | Cron scheduling (git-backed) | 0.5–1d | none | low | independent |
+| 2 | Sub-agents | ~1d | none | low-med | independent |
+| 3a | Rate-limit interceptor + `@bot status` | 0.5d | none | low | independent |
+| 4a | DMs | 0.5d | none | low | independent |
+| 3b | Two-account failover | ~1.5d | none | med | after 3a |
+| 4b | Auto-reply channels | ~1d | none | low-med | after 4a |
+| 3c | Auth health check | 0.5d | none | low | after 3b |
+
+**Recommended first PR:** Port 1 (scheduling) — highest value, fully self-contained, proves the git-memory-as-persistence pattern. **Total Path A:** ~6–8 engineering days.
+
+---
+
+## Open decisions (need a call before/while implementing)
+
+1. **Scheduled-task memory (Port 1):** v1 sets `skipMemoryLoad/Save: true` (clean, no pollution). Alternative: load `shared/` memory (not per-user) so scheduled tasks have repo context. *Recommendation: start with skip; revisit if schedules need context.*
+2. **Failover memory-save (Port 3b):** when the fallback account answers, do we also run the memory-save on the fallback session, or skip the save for fallback turns? *Recommendation: run save on whichever session succeeded; skip save entirely only if both error.*
+3. **Sub-agent personas (Port 2):** which initial personas to ship in `agents/`? *Recommendation: start with `repo-research-analyst` + `code-reviewer`; add more as `pr-review`/`plan` skills are ported.*
+4. **Auto-reply scope (Port 4b):** any Regenesis channel that should auto-reply on every top-level message, or keep it `@mention`/DM-only for now? *Recommendation: ship DMs (4a) first; defer 4b until a concrete channel use-case exists.*


### PR DESCRIPTION
Adds the two planning docs under `docs/`, referenced by the Path A tracking issue #65:

- **`docs/claw-bot-vs-agent-server-comparison.md`** — full comparison of `slack-claw-bot` vs `decentraland/agent-server`, capability matrix, the cross-org problem, and the rationale for choosing Path A.
- **`docs/path-a-implementation-plan.md`** — file-by-file plan for the four ports (#61–#64), sequencing, effort estimates, and open decisions.

Docs only — no code changes. Opening as a PR per repo convention (no direct pushes to `main`).

Related: #65 · #61 · #62 · #63 · #64

🤖 Generated with [Claude Code](https://claude.com/claude-code)