### PR TITLE
Surface silent agent failures to Slack

### DIFF
--- a/src/agent.ts
+++ b/src/agent.ts
@@ -274,6 +274,11 @@ export async function runAgent(options: RunOptions): Promise<RunResult> {
     // 2. Run agent
     console.log(`[agent] running (model: ${modelId}, prompt: ${prompt.slice(0, 200)})`);
     await session.prompt(prompt);
+
+    // prompt() resolves even on LLM/auth failures — surface them instead of an empty fallback.
+    const turnError = getTurnError(session.messages);
+    if (turnError) throw new Error(turnError);
+
     const rawResponse = session.getLastAssistantText() || "";
 
     // 3. Save memory async — response goes back to Slack immediately
@@ -510,6 +515,24 @@ function subscribeToDebugLogs(session: AgentSession): void {
         break;
     }
   });
+}
+
+/**
+ * Inspect the final assistant turn for a failed/aborted stopReason. pi-agent encodes
+ * LLM and auth errors this way rather than throwing, so this is the only signal that
+ * a turn silently failed. Returns the error text to throw, or null if the turn succeeded.
+ */
+export function getTurnError(messages: AgentMessage[]): string | null {
+  for (let i = messages.length - 1; i >= 0; i--) {
+    const msg = messages[i];
+    if (msg.role !== "assistant") continue;
+    const { stopReason, errorMessage } = msg as { stopReason?: string; errorMessage?: string };
+    if (stopReason === "error" || stopReason === "aborted") {
+      return errorMessage || `Agent turn ${stopReason} with no error detail`;
+    }
+    return null; // last assistant turn succeeded
+  }
+  return null;
 }
 
 function hasToolCalls(messages: AgentMessage[]): boolean {

--- a/test/agent.test.ts
+++ b/test/agent.test.ts
@@ -1,0 +1,43 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { getTurnError } from "../src/agent.js";
+import type { AgentMessage } from "@mariozechner/pi-agent-core";
+
+const assistant = (props: Record<string, unknown>): AgentMessage =>
+  ({ role: "assistant", content: [], ...props }) as unknown as AgentMessage;
+
+describe("getTurnError", () => {
+  it("returns null for a successful turn", () => {
+    assert.equal(getTurnError([assistant({ stopReason: "stop" })]), null);
+  });
+
+  it("surfaces the errorMessage when the last turn errored", () => {
+    const msgs = [assistant({ stopReason: "error", errorMessage: "401 unauthorized" })];
+    assert.equal(getTurnError(msgs), "401 unauthorized");
+  });
+
+  it("treats an aborted turn as a failure", () => {
+    const msgs = [assistant({ stopReason: "aborted" })];
+    assert.equal(getTurnError(msgs), "Agent turn aborted with no error detail");
+  });
+
+  it("falls back when error detail is missing", () => {
+    assert.equal(
+      getTurnError([assistant({ stopReason: "error" })]),
+      "Agent turn error with no error detail",
+    );
+  });
+
+  it("only inspects the final assistant turn (retry-then-succeed is ok)", () => {
+    const msgs = [
+      assistant({ stopReason: "error", errorMessage: "transient" }),
+      { role: "user", content: "retry", timestamp: 0 } as unknown as AgentMessage,
+      assistant({ stopReason: "stop" }),
+    ];
+    assert.equal(getTurnError(msgs), null);
+  });
+
+  it("returns null when there is no assistant message", () => {
+    assert.equal(getTurnError([]), null);
+  });
+});


### PR DESCRIPTION
## Summary

The bot would appear "down" — posting *"I wasn't able to produce a response."* and logging `0 tokens` — while no error surfaced anywhere.

Root cause: `@mariozechner/pi-coding-agent`'s `session.prompt()` **does not throw** on LLM/auth/API failures. It records a final assistant message with `stopReason: "error"` (or `"aborted"`) and an `errorMessage`, then resolves normally. So `runAgent` returned empty text / 0 tokens, slack.ts posted its bland empty-response fallback, and the real error was discarded — neither the `catch` in `runAgent` nor `submission.done.catch` in slack.ts fired, since both only react to thrown exceptions.

This adds `getTurnError()`, called right after `session.prompt()`. It inspects the final assistant turn and throws the underlying `errorMessage` when the turn failed, routing the failure into the existing error path: Slack now shows ❌ + *"Something went wrong: \<real error\>"* and the audit log records it.

## What could break

- Failures that previously surfaced as the soft "I wasn't able to produce a response." (⚠️) now surface as a hard error (❌ + message). This is the intended change — real errors are no longer masked.
- Only the **final** assistant turn is inspected, so auto-retry-then-succeed still counts as success (covered by a test).
- The grants path (`grants.ts`) also calls `runAgent`; a failed turn there will now throw into its existing try/catch ("Grants handler error") rather than returning empty — better surfacing, same handling.

## How to test

- `npm run build` — typechecks clean
- `npm test` — 84 tests pass, including 6 new `getTurnError` cases (success, error, aborted, missing-detail fallback, retry-then-succeed, empty)