### PR TITLE
Drop Redis OAuth persistence for long-lived setup token

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,7 +2,8 @@
 SLACK_BOT_TOKEN=xoxb-...
 SLACK_APP_TOKEN=xapp-...
 
-# Anthropic credentials
+# Anthropic credentials — long-lived OAuth token from `claude setup-token` (valid ~1 year).
+# Seeds .auth.json on first run; the SDK refreshes the access token in-place thereafter.
 ANTHROPIC_OAUTH_REFRESH_TOKEN=...
 
 # Optional: override the default model (default: claude-sonnet-4-5)
@@ -16,10 +17,6 @@ MAX_CONCURRENT_AGENTS=3
 
 # Optional: Slack channel ID for audit logging bot requests
 # LOG_CHANNEL_ID=C0123456789
-
-# Optional: persist OAuth tokens in Upstash Redis
-# UPSTASH_REDIS_REST_URL=https://...
-# UPSTASH_REDIS_REST_TOKEN=...
 
 # Optional: enable health check endpoint (GET /health/live)
 # HEALTH_PORT=5000

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -59,8 +59,8 @@ Sessions are ephemeral, stored in `/tmp/claw-sessions/`.
 NEVER use `ANTHROPIC_API_KEY`. All Anthropic auth uses OAuth sessions.
 
 - `.auth.json` stores `{ refresh, access, expires }` for the OAuth flow
-- Refresh tokens rotate on use — the file is the source of truth
-- The app seeds `.auth.json` from `ANTHROPIC_OAUTH_REFRESH_TOKEN` env var on first run, then persists rotated tokens via Redis
+- `ANTHROPIC_OAUTH_REFRESH_TOKEN` is a long-lived `claude setup-token` (~1 year)
+- The app seeds `.auth.json` from the env var on first run; the SDK refreshes the access token in-place. No external token store — if the file is lost on restart, the long-lived env token re-seeds it
 - The CLI reuses `.auth.json` directly
 
 ## Testing

--- a/README.md
+++ b/README.md
@@ -54,8 +54,6 @@ See [`.env.example`](.env.example) for all available options. Key variables:
 | `ANTHROPIC_OAUTH_REFRESH_TOKEN` | No* | Anthropic OAuth refresh token (see Auth section) |
 | `MODEL` | No | Model override (default: `claude-sonnet-4-5`). PR reviews always use `claude-opus-4-6` regardless of this setting. |
 | `MAX_CONCURRENT_AGENTS` | No | Max parallel agent runs (default: 3) |
-| `UPSTASH_REDIS_REST_URL` | No | Upstash Redis URL for OAuth token persistence |
-| `UPSTASH_REDIS_REST_TOKEN` | No | Upstash Redis token |
 | `LOG_CHANNEL_ID` | No | Slack channel ID for audit logging |
 | `HEALTH_PORT` | No | Port for health check endpoint (`GET /health/live`) |
 | `MEMORY_REPO` | No | GitHub repo for persistent memory (e.g. `owner/claw-memory`) |
@@ -78,8 +76,8 @@ See [`.env.example`](.env.example) for all available options. Key variables:
 
 All Anthropic auth uses OAuth — there is no API key path. The OAuth flow works like this:
 
-1. A **refresh token** is exchanged for a short-lived **access token** on each API call.
-2. The SDK may **rotate the refresh token** after use, so the original token becomes invalid.
+1. `ANTHROPIC_OAUTH_REFRESH_TOKEN` is a **long-lived setup token** (from `claude setup-token`, valid ~1 year).
+2. It is exchanged for a short-lived **access token**, which the SDK refreshes in-place as needed.
 3. The current auth state (refresh + access + expiry) is persisted in `.auth.json`.
 
 **Getting started:**
@@ -88,14 +86,7 @@ All Anthropic auth uses OAuth — there is no API key path. The OAuth flow works
 - **Existing session** — copy `.auth.json` from another pi-agent or OpenDCL session into the project root. No env var needed.
 - **CLI** — works if `.auth.json` exists (`npm run cli`). No env var needed.
 
-**Why `.auth.json` matters:** because refresh tokens rotate on use, the file is the source of truth. The env var is only a seed for first-time setup.
-
-**Why Redis:** container restarts lose the file, so the original env var token may already be expired. When Upstash Redis is configured (`UPSTASH_REDIS_REST_URL` / `UPSTASH_REDIS_REST_TOKEN`):
-
-1. **On startup** — the bot loads the latest auth state from Redis instead of the env var.
-2. **After each rotation** — the bot syncs the new state back to Redis.
-
-This keeps the bot resilient to restarts without manual token re-provisioning.
+**Restarts:** `.auth.json` holds the working auth state. If it's lost on a container restart, the bot simply re-seeds from `ANTHROPIC_OAUTH_REFRESH_TOKEN` — and because the setup token stays valid for ~1 year, that re-seed authenticates fine. No external token store is needed. Rotate the env token (and delete any stale `.auth.json`) once a year, or whenever auth starts failing with `No API key for provider: anthropic`.
 
 ### Memory persistence (git)
 

--- a/src/agent.ts
+++ b/src/agent.ts
@@ -133,17 +133,10 @@ function createGuardedTools(cwd: string): AgentTool<any>[] {
 
 // --- Types ---
 
-interface RedisConfig {
-  url: string;
-  token: string;
-}
-
 interface AgentConfig {
   anthropicOAuthRefreshToken?: string;
   githubToken?: string;
   model?: string;
-  upstashRedisUrl?: string;
-  upstashRedisToken?: string;
   memoryDir?: string;
 }
 
@@ -196,8 +189,6 @@ const REVIEW_KEYWORD_PATTERN = /\breview\b/i;
 let authStorage: AuthStorage | null = null;
 let defaultModelId: string;
 const authPath = join(projectDir, ".auth.json");
-let redisConfig: RedisConfig | null = null;
-let lastAuthSnapshot: string | null = null;
 let sessionDir: string | null = null;
 let memoryDir: string | null = null;
 
@@ -220,21 +211,8 @@ export async function initAgent(config: AgentConfig): Promise<void> {
   sessionDir = join(tmpdir(), "claw-sessions");
   mkdirSync(sessionDir, { recursive: true });
 
-  if (config.upstashRedisUrl && config.upstashRedisToken) {
-    redisConfig = { url: config.upstashRedisUrl, token: config.upstashRedisToken };
-  }
-
-  await loadAuth(config.anthropicOAuthRefreshToken);
+  loadAuth(config.anthropicOAuthRefreshToken);
   authStorage = AuthStorage.create(authPath);
-}
-
-export async function syncAuth(): Promise<void> {
-  if (!redisConfig || !existsSync(authPath)) return;
-  const data = readFileSync(authPath, "utf-8");
-  if (data === lastAuthSnapshot) return;
-  lastAuthSnapshot = data;
-  await redisSet(redisConfig, data);
-  console.log("[agent] Auth token rotated — synced to Redis");
 }
 
 export async function runAgent(options: RunOptions): Promise<RunResult> {
@@ -433,14 +411,12 @@ async function saveMemory(session: AgentSession, userId: string, username: strin
 
 // --- Auth ---
 
-async function loadAuth(refreshToken?: string): Promise<void> {
-  const stored = redisConfig ? await redisGet(redisConfig) : null;
-
-  if (stored) {
-    console.log("[agent] Loaded auth state from Redis");
-    writeFileSync(authPath, stored, "utf-8");
-    lastAuthSnapshot = stored;
-  } else if (existsSync(authPath)) {
+// Auth lives entirely in .auth.json. ANTHROPIC_OAUTH_REFRESH_TOKEN (a long-lived
+// `claude setup-token`, ~1 year) seeds the file on first run; the SDK rotates the
+// access token in-place thereafter. Because the seed stays valid for a year, a fresh
+// container that re-seeds from the env var still authenticates — no external store needed.
+function loadAuth(refreshToken?: string): void {
+  if (existsSync(authPath)) {
     console.log("[agent] Using existing .auth.json");
   } else if (refreshToken) {
     console.log("[agent] Seeding auth from ANTHROPIC_OAUTH_REFRESH_TOKEN");
@@ -449,31 +425,6 @@ async function loadAuth(refreshToken?: string): Promise<void> {
     }), "utf-8");
   } else {
     throw new Error("No auth available. Set ANTHROPIC_OAUTH_REFRESH_TOKEN or place a valid .auth.json");
-  }
-}
-
-async function redisGet(cfg: RedisConfig): Promise<string | null> {
-  try {
-    const res = await fetch(`${cfg.url}/get/anthropic_auth`, {
-      headers: { Authorization: `Bearer ${cfg.token}` },
-    });
-    const body = await res.json() as { result: string | null };
-    return body.result ?? null;
-  } catch (err) {
-    console.error("[agent] Failed to load from Redis:", err);
-    return null;
-  }
-}
-
-async function redisSet(cfg: RedisConfig, value: string): Promise<void> {
-  try {
-    await fetch(cfg.url, {
-      method: "POST",
-      headers: { Authorization: `Bearer ${cfg.token}`, "Content-Type": "application/json" },
-      body: JSON.stringify(["SET", "anthropic_auth", value]),
-    });
-  } catch (err) {
-    console.error("[agent] Failed to save to Redis:", err);
   }
 }
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -8,8 +8,6 @@ export interface Config {
   anthropicOAuthRefreshToken?: string;
   model?: string;
   maxConcurrentAgents: number;
-  upstashRedisUrl?: string;
-  upstashRedisToken?: string;
   logChannelId?: string;
   healthPort?: number;
   memoryRepo?: string;
@@ -29,8 +27,6 @@ export function loadConfig(): Config {
     anthropicOAuthRefreshToken: process.env.ANTHROPIC_OAUTH_REFRESH_TOKEN,
     model: process.env.MODEL,
     maxConcurrentAgents: parseInt(process.env.MAX_CONCURRENT_AGENTS || "3", 10),
-    upstashRedisUrl: process.env.UPSTASH_REDIS_REST_URL,
-    upstashRedisToken: process.env.UPSTASH_REDIS_REST_TOKEN,
     logChannelId: process.env.LOG_CHANNEL_ID,
     healthPort: process.env.HEALTH_PORT ? parseInt(process.env.HEALTH_PORT, 10) : undefined,
     memoryRepo: process.env.MEMORY_REPO,

--- a/src/index.ts
+++ b/src/index.ts
@@ -33,8 +33,6 @@ await initAgent({
   anthropicOAuthRefreshToken: config.anthropicOAuthRefreshToken,
   githubToken: config.githubToken,
   model: config.model,
-  upstashRedisUrl: config.upstashRedisUrl,
-  upstashRedisToken: config.upstashRedisToken,
   memoryDir,
 });
 

--- a/src/slack.ts
+++ b/src/slack.ts
@@ -1,7 +1,7 @@
 import { App, LogLevel } from "@slack/bolt";
 import type { WebClient } from "@slack/web-api";
 import type { Config } from "./config.js";
-import { runAgent, syncAuth, detectReviewModel } from "./agent.js";
+import { runAgent, detectReviewModel } from "./agent.js";
 import type { FileAttachment } from "./prompt.js";
 import { AgentScheduler } from "./concurrency.js";
 import type { GrantsRouter } from "./grants.js";
@@ -95,7 +95,6 @@ export function createSlackApp(
       });
 
       // Reply to Slack immediately — memory save continues in background
-      await syncAuth();
       await unreact(client, event.channel, event.ts, "rl-bonk-doge");
 
       if (response) {


### PR DESCRIPTION
## Summary

Removes the Upstash Redis dependency from the auth flow. Redis existed only to persist a **rotating** refresh token across container restarts — without it, a restart would re-seed `.auth.json` from the original env-var token, which had already been rotated away, causing the bot to silently fail with `No API key for provider: anthropic`.

With a **long-lived setup token** (`claude setup-token`, valid ~1 year) in `ANTHROPIC_OAUTH_REFRESH_TOKEN`, that whole workaround is unnecessary: the env seed stays valid for a year, so a restarted container re-seeds `.auth.json` and authenticates fine on its own.

Changes:
- `src/agent.ts` — removed `RedisConfig`, `redisConfig`/`lastAuthSnapshot` state, `syncAuth()`, `redisGet`/`redisSet`; `loadAuth()` is now synchronous (existing `.auth.json` → seed from env → throw)
- `src/slack.ts` — dropped the `await syncAuth()` call + import
- `src/config.ts`, `src/index.ts` — removed `upstashRedisUrl`/`upstashRedisToken` wiring
- `.env.example`, `README.md`, `CLAUDE.md` — removed the `UPSTASH_*` vars, documented the setup-token model

Net: −83 / +15 lines.

## What could break

- **Deploys relying on Redis for token persistence must switch to a setup token.** Set `ANTHROPIC_OAUTH_REFRESH_TOKEN` to a fresh `claude setup-token` and **delete any stale `.auth.json`** so it re-seeds. The `UPSTASH_*` env vars are now ignored and the `anthropic_auth` Redis key can be deleted.
- If a *short-lived* (non-setup) refresh token is ever used again, restarts on an ephemeral filesystem would reintroduce the original failure — this change assumes the long-lived token.
- No behavioral change for local dev / CLI: those already ran purely off `.auth.json`.

## How to test

- `npm run build` — typechecks clean
- `npm test` — 78 tests pass
- Manual: delete `.auth.json`, set `ANTHROPIC_OAUTH_REFRESH_TOKEN` to a setup token, start the bot, confirm it seeds `.auth.json` and responds. Restart and confirm it still authenticates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)