### PR TITLE
Default issue repo per Slack channel

### DIFF
--- a/skills/create-issue/SKILL.md
+++ b/skills/create-issue/SKILL.md
@@ -5,6 +5,14 @@ description: Create a GitHub issue from a Slack thread conversation. Analyzes th
 
 # Create GitHub Issue from Slack Thread
 
+## Choosing the repository
+
+Before anything else, determine the target repo:
+
+1. If the conversation explicitly names a repo or alias, use it.
+2. Otherwise, use the channel's default repo from the `repos` skill (matched against the `Channel: #name` line in the prompt).
+3. If neither applies, **ask the user which repo** — never guess or pick a repo from prior context.
+
 ## Steps
 
 1. **Analyze the thread** — identify the core request, problem, or feature

--- a/skills/repos/SKILL.md
+++ b/skills/repos/SKILL.md
@@ -14,3 +14,18 @@ description: Aliases for commonly used repositories. The agent can interact with
 When a user mentions one of these aliases, use the corresponding `owner/repo` for `gh` CLI commands.
 
 Users can also reference any public repo directly by its `owner/repo` name.
+
+## Channel defaults
+
+The prompt includes a `Channel: #name` line identifying the Slack channel the message came from. When an action needs a repo (e.g. creating an issue) and **no repo is explicitly named in the conversation**, default to the channel's repo below:
+
+| Channel | Default repo |
+|---------|-------------|
+| #mobile-support | decentraland/godot-explorer |
+| #project-bevy-explorer | decentraland/bevy-explorer |
+| #bevy-support | decentraland/bevy-explorer |
+
+Rules:
+- If the conversation explicitly names a repo or alias, that always wins over the channel default.
+- If no repo is named and the channel has a default, use it. **Never guess a repo.**
+- If no repo is named and the channel has no default here, ask the user which repo to use instead of guessing.

--- a/src/agent.ts
+++ b/src/agent.ts
@@ -153,6 +153,8 @@ export interface RunOptions {
   events?: EventEmitter;
   model?: string;
   files?: FileAttachment[];
+  /** Slack channel name, surfaced to the agent so it can resolve the channel's default repo. */
+  channelName?: string;
   /** Override the default system prompt (skips reading prompts/system.md). */
   systemPrompt?: string;
   /** Skip the post-run memory save. Used by grant agents whose learnings live elsewhere. */
@@ -353,7 +355,7 @@ async function createSession(
 
 async function buildNewPrompt(options: RunOptions): Promise<string> {
   const threadContent = await options.fetchThread();
-  return buildPrompt(threadContent, options.dryRun, options.triggeredBy, undefined, options.files);
+  return buildPrompt(threadContent, options.dryRun, options.triggeredBy, undefined, options.files, options.channelName);
 }
 
 async function buildResumePrompt(options: RunOptions, sessionManager: SessionManager): Promise<string> {
@@ -368,7 +370,7 @@ async function buildResumePrompt(options: RunOptions, sessionManager: SessionMan
       );
     }
   }
-  return buildPrompt(options.newMessage, options.dryRun, options.triggeredBy, true, options.files);
+  return buildPrompt(options.newMessage, options.dryRun, options.triggeredBy, true, options.files, options.channelName);
 }
 
 function findLastSeenTs(sessionManager: SessionManager): string | null {

--- a/src/prompt.ts
+++ b/src/prompt.ts
@@ -10,13 +10,17 @@ export function buildPrompt(
   triggeredBy?: string,
   isFollowUp?: boolean,
   files?: FileAttachment[],
+  channelName?: string,
 ): string {
   const dryRunNotice = dryRun
     ? "IMPORTANT: Do not execute any commands. Just describe what you would do.\n\n"
     : "";
 
-  const attribution = triggeredBy
-    ? `Triggered by: ${triggeredBy}\n\n`
+  const attributionLines: string[] = [];
+  if (channelName) attributionLines.push(`Channel: #${channelName}`);
+  if (triggeredBy) attributionLines.push(`Triggered by: ${triggeredBy}`);
+  const attribution = attributionLines.length
+    ? `${attributionLines.join("\n")}\n\n`
     : "";
 
   const fileSection = files?.length

--- a/src/slack.ts
+++ b/src/slack.ts
@@ -92,6 +92,7 @@ export function createSlackApp(
         triggeredBy: userName,
         model: detectReviewModel(text),
         files,
+        channelName,
       });
 
       // Reply to Slack immediately — memory save continues in background


### PR DESCRIPTION
## Summary

The bot was creating GitHub issues in arbitrary repositories. The agent chose the target repo solely from the conversation text, and the Slack channel was never surfaced to it — so when a thread didn't explicitly name a repo, it guessed.

This change:
- **Surfaces the channel to the agent** — `buildPrompt` now emits a `Channel: #name` line (`prompt.ts`); `channelName` is threaded through `RunOptions` (`agent.ts`) and passed from the Slack handler using the already-resolved name (`slack.ts`).
- **Adds a channel→repo mapping + fallback rule** in the skills (markdown, per the skills-over-features convention):
  - `repos` skill gains a **Channel defaults** table.
  - `create-issue` skill gains a "Choosing the repository" step: explicit repo wins → else channel default → else *ask, never guess*.

## What could break

- Behavior is opt-in via the table: channels not listed fall through to "ask the user" rather than guessing — slightly more conservative than before.
- The table keys on **channel name**, so renaming a channel requires updating the table. (Could switch to stable channel IDs later if preferred.)
- No change to grants flow or any other agent path.

## How to test

1. `npm run build && npm test` — build clean, 84/84 tests pass.
2. In a mapped channel (e.g. `#mobile-support`), ask the bot to create an issue without naming a repo → it should target the channel's default repo.
3. Explicitly name a different repo in the same channel → the explicit repo wins.
4. In an unmapped channel with no repo named → the bot asks which repo instead of guessing.